### PR TITLE
상장 폐지 종목 처리

### DIFF
--- a/app/src/main/java/com/trueedu/project/model/dto/price/PriceResponse.kt
+++ b/app/src/main/java/com/trueedu/project/model/dto/price/PriceResponse.kt
@@ -28,7 +28,7 @@ data class PriceDetail(
     @SerialName("new_hgpr_lwpr_cls_code")
     val newHighLow: String?, // 신 고가 저가 구분 코드 조회하는 종목이 신고/신저에 도달했을 경우에만 조회됨
     @SerialName("bstp_kor_isnm")
-    val sectorNameKr: String, // 업종 한글 종목명
+    val sectorNameKr: String?, // 업종 한글 종목명
     @SerialName("temp_stop_yn")
     val tempStop: String, // 임시 정지 여부
 


### PR DESCRIPTION
상장폐지 종목의 실시간 가격 응답에 종목 이름이 비어서 온다
그래서 해당 필드를 nullable 로 선언함

상폐 종목은 가격 요청을 안 하는 게 맞는데 추후 수정 예정