### PR TITLE
종목 업데이트 시 기존 종목 데이터는 모두 제거

### DIFF
--- a/app/src/main/java/com/trueedu/project/data/StockPool.kt
+++ b/app/src/main/java/com/trueedu/project/data/StockPool.kt
@@ -96,6 +96,7 @@ class StockPool @Inject constructor(
         val localStockInfoList = stocks.map {
             StockInfoLocal(it.code, it.nameKr, it.attributes, it.kospi())
         }
+        stockLocal.deleteAllStocks()
         stockLocal.setAllStocks(localStockInfoList)
     }
 
@@ -149,12 +150,6 @@ class StockPool @Inject constructor(
 
     fun search(predicate: (StockInfo) -> Boolean): List<StockInfo> {
         return stocks.values.filter(predicate)
-    }
-
-    private fun currentTimeToyyyyMMdd(): Long {
-        val currentDate = Date()
-        val formatter = SimpleDateFormat("yyyyMMdd", Locale.getDefault())
-        return formatter.format(currentDate).toLong()
     }
 
     /**

--- a/app/src/main/java/com/trueedu/project/db/stocks/StockInfoLocalDao.kt
+++ b/app/src/main/java/com/trueedu/project/db/stocks/StockInfoLocalDao.kt
@@ -19,4 +19,7 @@ interface StockInfoLocalDao {
 
     @Query("SELECT * FROM stocks")
     suspend fun getAllStocks(): List<StockInfoLocal>
+
+    @Query("DELETE FROM stocks")
+    suspend fun deleteAllStocks()
 }

--- a/app/src/main/java/com/trueedu/project/repository/local/StockLocal.kt
+++ b/app/src/main/java/com/trueedu/project/repository/local/StockLocal.kt
@@ -14,4 +14,8 @@ class StockLocal @Inject constructor(
     suspend fun setAllStocks(stocks: List<StockInfoLocal>)  {
         return stockInfoLocalDao.insertAll(stocks)
     }
+
+    suspend fun deleteAllStocks()  {
+        return stockInfoLocalDao.deleteAllStocks()
+    }
 }


### PR DESCRIPTION
상장 폐지 등의 종목이 남아 있을 수 있어서
local database 는 새로 갱신하게 함

상장 폐지 종목을 남겨두어도 관계 없지만
시세 등을 지원하지 않아 별도 처리가 번거롭기 때문에 그냥 제거함