### PR TITLE
dart 전자 공시 초기화 오류

### DIFF
--- a/app/src/main/java/com/trueedu/project/data/DartManager.kt
+++ b/app/src/main/java/com/trueedu/project/data/DartManager.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
@@ -50,6 +51,10 @@ class DartManager @Inject constructor(
 
             if (hasApiKey && now - lastUpdatedAtRemote > 30) { // 30 minutes
                 // 다시 로딩
+                while (spacManager.loading.value) {
+                    Log.d(TAG, "waiting spacManager")
+                    delay(200)
+                }
                 val list = spacManager.spacList.value
                 loadList(list.map { it.code })
                 Log.d(TAG, "lastUpdatedAt: $lastUpdatedAt")
@@ -72,10 +77,10 @@ class DartManager @Inject constructor(
     }
 
     fun getListMap(): Map<String, List<DartListItem>> {
-        return items.toMap()
+        return items
     }
 
-    suspend fun loadList(codes: List<String>) {
+    fun loadList(codes: List<String>) {
         if (local.dartApiKey.isBlank()) return
 
         val fromDate = LocalDate.now()


### PR DESCRIPTION
전자 공시 대상 종목을 받아오기 전에 dart api 를 시도하여
공시 결과가 empty 가 되는 문제
spacManager 초기화 후에 loadList() 를 호출해야 함