### PR TITLE
스팩 일정에서 날짜를 8자리로 끊어 읽기

### DIFF
--- a/app/src/main/java/com/trueedu/project/ui/spac/SpacScheduleFragment.kt
+++ b/app/src/main/java/com/trueedu/project/ui/spac/SpacScheduleFragment.kt
@@ -91,7 +91,7 @@ class SpacScheduleFragment: BaseFragment() {
                     .verticalScroll(state)
             ) {
                 list.map { (date, schedule) ->
-                    val dateString = dateFormat(date)
+                    val dateString = dateFormat(date.take(8))
                     val isPast = LocalDate.now().yyyyMMdd().let { now ->
                         date < now
                     }


### PR DESCRIPTION
스팩 일정에서 데이터 key 로 날짜(yyyyMMdd)를 사용하므로
날짜가 겹칠 경우 처리가 불가능했는데
뒤에 숫자를 추가해서 중복을 피하게 수정함
이때 데이터를 보여줄 때는 8자리 값으로 포매팅하여
적절히 날짜가 표시되게 함