### PR TITLE
GH-283 관심 종목 읽기에서 크래시 수정

### DIFF
--- a/app/src/main/java/com/trueedu/project/data/WatchList.kt
+++ b/app/src/main/java/com/trueedu/project/data/WatchList.kt
@@ -42,7 +42,7 @@ class WatchList @Inject constructor(
                     } else { // logout
                         withContext(Dispatchers.Main) {
                             groupNames.value = emptyList()
-                            fillDefaultList(null)
+                            fillDefaultList(emptyList())
                         }
                     }
                 }
@@ -162,9 +162,9 @@ class WatchList @Inject constructor(
     /**
      * 크기가 MAX_GROUP_SIZE 인 리스트를 만들어서 list 에 넣는다.
      */
-    private fun fillDefaultList(loadedData: List<List<String>>?) {
+    private fun fillDefaultList(loadedData: List<List<String>>) {
         list.value = MutableList(MAX_GROUP_SIZE) {
-            loadedData?.getOrNull(it) ?: listOf()
+            loadedData.getOrNull(it) ?: listOf()
         }
     }
 }

--- a/app/src/main/java/com/trueedu/project/data/firebase/FirebaseWatchManager.kt
+++ b/app/src/main/java/com/trueedu/project/data/firebase/FirebaseWatchManager.kt
@@ -58,9 +58,21 @@ class FirebaseWatchManager @Inject constructor(
 
         val ref = database.getReference("users") // 종목 데이터
         val snapshot = ref.child(userId).child("watch")
-        val list = snapshot.get().await()
-            .getValue(object : GenericTypeIndicator<List<List<String>>>() {})
-        return list ?: emptyList()
+        try {
+            val list = snapshot.get().await()
+                .getValue(object : GenericTypeIndicator<List<List<String>>>() {})
+
+            return list ?: emptyList()
+        } catch (e: Exception) {
+            val list = snapshot.get().await()
+                .getValue(object : GenericTypeIndicator<Map<String, List<String>>>() {})
+                ?.let { m ->
+                    (0 until MAX_GROUP_SIZE).map {
+                        m[it.toString()] ?: emptyList()
+                    }
+                }
+            return list ?: emptyList()
+        }
     }
 
     fun writeWatchList(list :List<List<String>>) {


### PR DESCRIPTION
관심 종목을 삭제한 후 특정 그룹이 empty 가 된 후에
다시 관심 종목 데이터를 읽으면 List 가 아닌 Map 형식으로 파싱을 시도함
따라서, List 와 Map 형식을 모두 읽을 수 있게 코드를 추가함