### PR TITLE
스팩 스케쥴 어드민 개선

### DIFF
--- a/app/src/main/java/com/trueedu/project/admin/spac/SpacScheduleAdminFragment.kt
+++ b/app/src/main/java/com/trueedu/project/admin/spac/SpacScheduleAdminFragment.kt
@@ -131,6 +131,12 @@ class SpacScheduleAdminFragment: BaseFragment() {
     }
 
     private fun onSave() {
+        val keySize = list.map { it.first }.toSet().count()
+        if (keySize != list.size) {
+            Toast.makeText(requireContext(), "날짜 중복 !!", Toast.LENGTH_SHORT).show()
+            return
+        }
+
         MainScope().launch {
             loading.value = true
             spacStatusManager.writeSpacSchedule(

--- a/app/src/main/java/com/trueedu/project/data/firebase/SpacStatusManager.kt
+++ b/app/src/main/java/com/trueedu/project/data/firebase/SpacStatusManager.kt
@@ -129,6 +129,7 @@ class SpacStatusManager @Inject constructor(
 
         snapshot.setValue(m)
             .addOnSuccessListener {
+                spacScheduleList = m
                 onSuccess()
             }
             .addOnFailureListener {


### PR DESCRIPTION
스케쥴 저장 후에 즉시 현재 상태도 반영하기
스케쥴에 중복 날짜가 있으면 저장하지 않고 실패 메시지