### PR TITLE
dart 공시 호출 날짜를 평일로 제한

### DIFF
--- a/app/src/main/java/com/trueedu/project/data/DartManager.kt
+++ b/app/src/main/java/com/trueedu/project/data/DartManager.kt
@@ -7,19 +7,16 @@ import com.trueedu.project.dart.repository.remote.DartRemote
 import com.trueedu.project.data.firebase.FirebaseDartManager
 import com.trueedu.project.data.spac.SpacManager
 import com.trueedu.project.repository.local.Local
+import com.trueedu.project.utils.latestWorkDay
 import com.trueedu.project.utils.yyyyMMddHHmm
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
-import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
-import java.time.DayOfWeek
-import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 import java.util.Date
 import java.util.concurrent.ConcurrentHashMap
@@ -85,14 +82,7 @@ class DartManager @Inject constructor(
     suspend fun CoroutineScope.loadList(codes: List<String>) {
         if (local.dartApiKey.isBlank()) return
 
-        val fromDate = LocalDate.now()
-            .let {
-                when (it.dayOfWeek) {
-                    DayOfWeek.SATURDAY -> it.minusDays(1)
-                    DayOfWeek.SUNDAY -> it.minusDays(2)
-                    else -> it
-                }
-            }
+        val fromDate = latestWorkDay()
             .format(DateTimeFormatter.ofPattern("yyyyMMdd"))
 
         // 모든 API 호출을 동시에 실행하고 결과를 기다림

--- a/app/src/main/java/com/trueedu/project/utils/DateTimeUtils.kt
+++ b/app/src/main/java/com/trueedu/project/utils/DateTimeUtils.kt
@@ -1,6 +1,7 @@
 package com.trueedu.project.utils
 
 import java.text.SimpleDateFormat
+import java.time.DayOfWeek
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
@@ -36,3 +37,41 @@ fun stringToLocalDate(yyyyMMdd: String): LocalDate {
     val formatter = DateTimeFormatter.ofPattern("yyyyMMdd")
     return LocalDate.parse(yyyyMMdd, formatter)
 }
+
+// 오늘 포함 가장 가까운 평일 반환 (주식 장이 열리는 날)
+fun latestWorkDay(): LocalDate {
+    var date = LocalDate.now()
+    while (date.isHoliday()) {
+        date = date.minusDays(1)
+    }
+    return date
+}
+
+fun LocalDate.isHoliday(): Boolean {
+    return when (this.dayOfWeek) {
+        DayOfWeek.SATURDAY,
+        DayOfWeek.SUNDAY -> true
+        else -> {
+            holidays.contains(this)
+        }
+    }
+}
+
+// 몇 개 안 되니까 그냥 하드 코딩
+// 주식 장이 열리지 않는 날
+private val holidays = setOf(
+    LocalDate.of(2025, 5, 1),
+    LocalDate.of(2025, 5, 5),
+    LocalDate.of(2025, 5, 6),
+    LocalDate.of(2025, 6, 3),
+    LocalDate.of(2025, 6, 6),
+    LocalDate.of(2025, 8, 15),
+    LocalDate.of(2025, 10, 3),
+    LocalDate.of(2025, 10, 6),
+    LocalDate.of(2025, 10, 7),
+    LocalDate.of(2025, 10, 8),
+    LocalDate.of(2025, 10, 9),
+    LocalDate.of(2025, 12, 25),
+    LocalDate.of(2025, 12, 31),
+    LocalDate.of(2026, 1, 1),
+)


### PR DESCRIPTION
기존 토,일요일 뿐 아니라 실제 휴일도 체크하여
가장 가까운 평일에 대해서 공시 api 를 호출하게 함