### PR TITLE
AGP 9/Kotlin 2.3/Gradle 9.1로 업데이트 및 마이그레이션

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,13 +1,11 @@
 plugins {
     alias(libs.plugins.android.application)
-    alias(libs.plugins.jetbrains.kotlin.android)
     alias(libs.plugins.compose.compiler)
     alias(libs.plugins.hilt)
     alias(libs.plugins.devtools.ksp)
     alias(libs.plugins.kotlinSerialization)
     alias(libs.plugins.googleServices)
     alias(libs.plugins.firebase.crashlytics)
-    alias(libs.plugins.firebase.performance)
 }
 
 apply from: 'versions.gradle'
@@ -22,8 +20,8 @@ def getLocalProperty(String propertyName) {
 }
 
 android {
-    namespace 'com.trueedu.project'
-    compileSdk 34
+    namespace = 'com.trueedu.project'
+    compileSdk 36
 
     signingConfigs {
         devconfig {
@@ -49,7 +47,7 @@ android {
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {
-            useSupportLibrary true
+            useSupportLibrary = true
         }
 
         resValue("string", "admob_id", "ca-app-pub-3613096182343800~8743264607")
@@ -61,15 +59,15 @@ android {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
-            signingConfig signingConfigs.upload
+            signingConfig = signingConfigs.upload
             firebaseCrashlytics {
-                mappingFileUploadEnabled true
+                mappingFileUploadEnabled = true
             }
         }
         debug {
             debuggable true
             firebaseCrashlytics {
-                mappingFileUploadEnabled false
+                mappingFileUploadEnabled = false
             }
             resValue("string", "native_ad_unit_id", "ca-app-pub-3940256099942544/2247696110")
         }
@@ -78,15 +76,10 @@ android {
         sourceCompatibility JavaVersion.VERSION_17
         targetCompatibility JavaVersion.VERSION_17
     }
-    kotlinOptions {
-        jvmTarget = '17'
-    }
     buildFeatures {
-        buildConfig true
-        compose true
-    }
-    composeOptions {
-        kotlinCompilerExtensionVersion '1.5.1'
+        buildConfig = true
+        resValues = true
+        compose = true
     }
     packaging {
         resources {
@@ -95,6 +88,12 @@ android {
     }
     hilt {
         enableAggregatingTask = false
+    }
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
     }
 }
 
@@ -113,7 +112,7 @@ dependencies {
     implementation libs.material
     implementation libs.material.extended
     implementation libs.androidx.lifecycle.process
-    implementation libs.firebase.auth.ktx
+    implementation libs.firebase.auth
     implementation libs.androidx.room.common
     implementation libs.androidx.room.ktx
     testImplementation libs.junit
@@ -144,7 +143,7 @@ dependencies {
     implementation(libs.google.play.services)
     implementation(libs.google.play.services.ads)
     implementation(libs.play.services.appset)
-    implementation(libs.accompanist.navigation.material)
+    implementation(libs.androidx.compose.material.navigation)
     implementation(libs.navigation.compose)
     implementation(libs.navigation.fragment)
     implementation(libs.coil.compose)

--- a/app/src/main/java/com/trueedu/project/ui/widget/DragDropList.kt
+++ b/app/src/main/java/com/trueedu/project/ui/widget/DragDropList.kt
@@ -99,7 +99,7 @@ fun <T : Any> dragDropColumn(
                         val item = items[position]
                         Card(
                             modifier = Modifier
-                                .animateItemPlacement()
+                                .animateItem()
                                 .alpha(if (itemDragState.currentIndex.value == position) 0f else 1f),
                             shape = RectangleShape,
                             colors = CardColors(

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,29 +1,27 @@
 [versions]
-agp = "8.13.2"
-kotlin = "2.0.21"
-coreKtx = "1.13.1"
+agp = "9.0.0"
+kotlin = "2.3.10"
+coreKtx = "1.15.0"
 junit = "4.13.2"
-junitVersion = "1.2.1"
-espressoCore = "3.6.1"
-lifecycleRuntimeKtx = "2.8.7"
-activityCompose = "1.9.2"
-composeBom = "2025.02.00"
-room = "2.6.1"
-hilt = "2.56.1"
-ksp = "2.0.21-1.0.25"
-retrofit = "2.9.0"
-chucker = "4.0.0"
-okhttp-bom = "4.11.0"
-flipper = "0.240.0"
-material = "1.12.0"
-lifecycleProcess = "2.8.7"
-firebaseAuthKtx = "23.2.0"
-symbolProcessingApi = "2.0.21-1.0.25"
+junitVersion = "1.3.0"
+espressoCore = "3.7.0"
+lifecycleRuntimeKtx = "2.10.0"
+activityCompose = "1.12.2"
+composeBom = "2025.12.00"
+room = "2.8.4"
+hilt = "2.59.1"
+ksp = "2.3.5"
+retrofit = "2.12.0"
+chucker = "4.2.0"
+okhttp-bom = "4.12.0"
+flipper = "0.273.0"
+material = "1.13.0"
+lifecycleProcess = "2.10.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
-androidx-appcompat = { module = "androidx.appcompat:appcompat", version = "1.7.0" }
+androidx-appcompat = { module = "androidx.appcompat:appcompat", version = "1.7.1" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }
 androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycleRuntimeKtx" }
@@ -36,14 +34,14 @@ androidx-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-toolin
 androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
-androidx-fragment = { module = "androidx.fragment:fragment-ktx", version = "1.8.6" }
+androidx-fragment = { module = "androidx.fragment:fragment-ktx", version = "1.8.9" }
 hilt = { module = "com.google.dagger:hilt-android", version.ref = "hilt" }
 hilt-compiler = { module = "com.google.dagger:hilt-compiler", version.ref = "hilt" }
-hilt-androidx-compiler = { module = "androidx.hilt:hilt-compiler", version = "1.2.0" }
-hilt-navigation-compose = { module = "androidx.hilt:hilt-navigation-compose", version = "1.2.0" }
-hilt-worker = { module = "androidx.hilt:hilt-work", version = "1.2.0" }
-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version = "2.8.8" }
-navigation-fragment = { group = "androidx.navigation", name = "navigation-fragment-ktx", version = "2.8.8" }
+hilt-androidx-compiler = { module = "androidx.hilt:hilt-compiler", version = "1.3.0" }
+hilt-navigation-compose = { module = "androidx.hilt:hilt-navigation-compose", version = "1.3.0" }
+hilt-worker = { module = "androidx.hilt:hilt-work", version = "1.3.0" }
+navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version = "2.9.7" }
+navigation-fragment = { group = "androidx.navigation", name = "navigation-fragment-ktx", version = "2.9.7" }
 androidx-room = { module = "androidx.room:room-runtime", version.ref = "room" }
 androidx-room-compiler = { module = "androidx.room:room-compiler", version.ref = "room" }
 androidx-room-common = { group = "androidx.room", name = "room-common", version.ref = "room" }
@@ -54,7 +52,7 @@ retrofit = { group = "com.squareup.retrofit2", name = "retrofit", version.ref = 
 retrofit-serialization = { group = "com.jakewharton.retrofit", name = "retrofit2-kotlinx-serialization-converter", version = "1.0.0" }
 chucker-debug = { group = "com.github.chuckerteam.chucker", name = "library", version.ref = "chucker" }
 chucker-release = { group = "com.github.chuckerteam.chucker", name = "library-no-op", version.ref = "chucker" }
-kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version = "1.6.3" }
+kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version = "1.10.0" }
 okhttp-bom = { group = "com.squareup.okhttp3", name = "okhttp-bom", version.ref = "okhttp-bom" }
 okhttp = { group = "com.squareup.okhttp3", name = "okhttp" }
 okhttp-logging-interceptor = { group = "com.squareup.okhttp3", name = "logging-interceptor" }
@@ -64,21 +62,21 @@ flipper-network-plugin = { group = "com.facebook.flipper", name = "flipper-netwo
 flipper-noop = { group = "com.github.theGlenn", name = "flipper-android-no-op", version = "0.10.0" }
 soloader = { group = "com.facebook.soloader", name = "soloader", version = "0.11.0" }
 material = { group = "com.google.android.material", name = "material", version.ref = "material" }
-material-extended = { group = "androidx.compose.material", name ="material-icons-extended", version = "1.7.8" }
+material-extended = { group = "androidx.compose.material", name = "material-icons-extended" }
 amplitude = { module = "com.amplitude:android-sdk", version = "3.35.1" }
 androidx-lifecycle-process = { group = "androidx.lifecycle", name = "lifecycle-process", version.ref = "lifecycleProcess" }
 
-firebase-bom = { group = "com.google.firebase", name = "firebase-bom", version = "33.10.0" }
-firebase-database = { module = "com.google.firebase:firebase-database-ktx" }
-firebase-auth-ktx = { group = "com.google.firebase", name = "firebase-auth-ktx", version.ref = "firebaseAuthKtx" }
-firebase-performance = { module = "com.google.firebase:firebase-perf-ktx" }
-firebase-analytics = { module = "com.google.firebase:firebase-analytics-ktx" }
-firebase-crashlytics = { module = "com.google.firebase:firebase-crashlytics-ktx" }
-google-play-services = { group = "com.google.android.gms", name = "play-services-auth", version = "21.3.0" }
-google-play-services-ads = { module = "com.google.android.gms:play-services-ads", version = "24.0.0" }
-accompanist-navigation-material = { group = "com.google.accompanist", name = "accompanist-navigation-material", version = "0.32.0" }
-coil-compose = { module = "io.coil-kt:coil-compose", version = "2.3.0" }
-symbol-processing-api = { module = "com.google.devtools.ksp:symbol-processing-api", version.ref = "symbolProcessingApi" }
+firebase-bom = { group = "com.google.firebase", name = "firebase-bom", version = "34.9.0" }
+firebase-database = { module = "com.google.firebase:firebase-database" }
+firebase-auth = { module = "com.google.firebase:firebase-auth" }
+firebase-performance = { module = "com.google.firebase:firebase-perf" }
+firebase-analytics = { module = "com.google.firebase:firebase-analytics" }
+firebase-crashlytics = { module = "com.google.firebase:firebase-crashlytics" }
+google-play-services = { group = "com.google.android.gms", name = "play-services-auth", version = "21.5.0" }
+google-play-services-ads = { module = "com.google.android.gms:play-services-ads", version = "24.9.0" }
+androidx-compose-material-navigation = { module = "androidx.compose.material:material-navigation" }
+coil-compose = { module = "io.coil-kt:coil-compose", version = "2.6.0" }
+symbol-processing-api = { module = "com.google.devtools.ksp:symbol-processing-api", version.ref = "ksp" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
@@ -89,8 +87,8 @@ kotlinKapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kotlin" }
 hilt = {id = "com.google.dagger.hilt.android", version.ref = "hilt" }
 devtools-ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 kotlinParcelize = { id = "org.jetbrains.kotlin.plugin.parcelize", version.ref = "kotlin" }
-googleServices = { id = "com.google.gms.google-services", version = "4.4.2" }
-firebase-crashlytics = { id = "com.google.firebase.crashlytics", version = "3.0.3" }
+googleServices = { id = "com.google.gms.google-services", version = "4.4.4" }
+firebase-crashlytics = { id = "com.google.firebase.crashlytics", version = "3.0.6" }
 firebase-performance = { id = "com.google.firebase.firebase-perf", version = "1.4.2" }
 
 [bundles]

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Sat Sep 21 17:10:09 KST 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.1.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle
+++ b/settings.gradle
@@ -19,7 +19,7 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
-        maven { url "https://jitpack.io" }
+        maven { url = "https://jitpack.io" }
     }
 }
 


### PR DESCRIPTION
Gradle Wrapper 9.1.0, AGP 9.0.0, Kotlin 2.3.10
주요 라이브러리(Compose/Firebase/AndroidX) 최신화

AGP 9 내장 Kotlin 대응(불필요 플러그인 제거, compilerOptions로 전환) 및 compileSdk 36 상향 Firebase BoM 34 대응으로 KTX 의존성 제거, accompanist navigation-material → AndroidX 대체 Compose 리스트 애니메이션 API 변경 반영 및 빌드 복구
Gradle 10 대비 Groovy DSL deprecation 경고 제거(prop = value 문법으로 정리)