### PR TITLE
feat: 웹소켓 실시간 체결 이벤트 notification 표시

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,6 +5,7 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.DOWNLOAD_WITHOUT_NOTIFICATION" />
     <uses-permission android:name="com.google.android.gms.permission.AD_ID" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
     <application
         android:name="com.trueedu.project.App"

--- a/app/src/main/java/com/trueedu/project/App.kt
+++ b/app/src/main/java/com/trueedu/project/App.kt
@@ -17,6 +17,7 @@ import com.trueedu.project.data.log.ReleaseTree
 import com.trueedu.project.data.realtime.RealOrderManager
 import com.trueedu.project.data.realtime.RealPriceManager
 import com.trueedu.project.data.realtime.WsMessageHandler
+import com.trueedu.project.notification.TradeNotificationWorker
 import com.trueedu.project.repository.local.Local
 import com.trueedu.project.ui.ads.AdmobManager
 import com.trueedu.project.worker.DailyAlarmManager
@@ -46,6 +47,7 @@ class App : Application(), LifecycleEventObserver {
         fun getDartManager(): DartManager
         fun getTrueAnalytics(): TrueAnalytics
         fun getAdmobManager(): AdmobManager
+        fun getTradeNotificationWorker(): TradeNotificationWorker
     }
 
     override fun onCreate() {
@@ -79,6 +81,7 @@ class App : Application(), LifecycleEventObserver {
         val dartManager = entryPointInjector(InjectModule::class.java).getDartManager()
         val trueAnalytics = entryPointInjector(InjectModule::class.java).getTrueAnalytics()
         val admobManager = entryPointInjector(InjectModule::class.java).getAdmobManager()
+        val tradeNotificationWorker = entryPointInjector(InjectModule::class.java).getTradeNotificationWorker()
 
         when (event) {
             Lifecycle.Event.ON_CREATE -> {
@@ -90,6 +93,7 @@ class App : Application(), LifecycleEventObserver {
                 wsMessage.start()
                 realPriceManager.start()
                 realOrderManager.start()
+                tradeNotificationWorker.start()
                 stockPool.loadStockInfo()
                 dartManager.init()
                 admobManager.start()
@@ -101,6 +105,7 @@ class App : Application(), LifecycleEventObserver {
                 wsMessage.stop()
                 realPriceManager.stop()
                 realOrderManager.stop()
+                tradeNotificationWorker.stop()
                 admobManager.stop()
             }
 

--- a/app/src/main/java/com/trueedu/project/MainActivity.kt
+++ b/app/src/main/java/com/trueedu/project/MainActivity.kt
@@ -3,6 +3,7 @@ package com.trueedu.project
 import android.app.DownloadManager
 import android.content.Intent
 import android.content.IntentFilter
+import android.content.pm.PackageManager
 import android.net.Uri
 import android.os.Build
 import android.os.Bundle
@@ -12,9 +13,12 @@ import androidx.activity.OnBackPressedCallback
 import androidx.activity.SystemBarStyle
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.annotation.RequiresApi
+import android.annotation.SuppressLint
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.content.ContextCompat
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.snapshotFlow
 import androidx.lifecycle.lifecycleScope
@@ -81,6 +85,12 @@ class MainActivity : AppCompatActivity() {
     // 앱이 백그라운드로 진입할 때의 시각(모노토닉) 저장
     private var lastBackgroundElapsedRealtime = SystemClock.elapsedRealtime()
 
+    // Android 13+ 알림 권한 요청 launcher
+    private val requestNotificationPermissionLauncher =
+        registerForActivityResult(ActivityResultContracts.RequestPermission()) { isGranted ->
+            logD("POST_NOTIFICATIONS permission granted: $isGranted")
+        }
+
     override fun onStart() {
         super.onStart()
         if (screen.keepScreenOn.value) {
@@ -110,6 +120,7 @@ class MainActivity : AppCompatActivity() {
 
         googleAccount.init(this)
         trueAnalytics.enterView("main__enter")
+        requestNotificationPermissionIfNeeded()
 
         val filter = IntentFilter(DownloadManager.ACTION_DOWNLOAD_COMPLETE)
         registerReceiver(downloadCompleteReceiver, filter, RECEIVER_EXPORTED)
@@ -249,6 +260,16 @@ class MainActivity : AppCompatActivity() {
                 .collectLatest {
                     keepScreenOnOff(it)
                 }
+        }
+    }
+
+    @SuppressLint("InlinedApi")
+    private fun requestNotificationPermissionIfNeeded() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            val permission = android.Manifest.permission.POST_NOTIFICATIONS
+            if (ContextCompat.checkSelfPermission(this, permission) != PackageManager.PERMISSION_GRANTED) {
+                requestNotificationPermissionLauncher.launch(permission)
+            }
         }
     }
 

--- a/app/src/main/java/com/trueedu/project/notification/TradeNotificationManager.kt
+++ b/app/src/main/java/com/trueedu/project/notification/TradeNotificationManager.kt
@@ -1,0 +1,106 @@
+package com.trueedu.project.notification
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import com.trueedu.project.MainActivity
+import com.trueedu.project.R
+import com.trueedu.project.model.ws.RealTimeTrade
+import dagger.hilt.android.qualifiers.ApplicationContext
+import java.util.concurrent.atomic.AtomicInteger
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class TradeNotificationManager @Inject constructor(
+    @ApplicationContext private val context: Context,
+) {
+    companion object {
+        const val CHANNEL_ID = "trade_realtime"
+        const val CHANNEL_NAME = "실시간 체결 알림"
+        const val CHANNEL_DESCRIPTION = "웹소켓으로 수신된 실시간 체결 이벤트를 알림으로 표시합니다"
+    }
+
+    private val notificationIdCounter = AtomicInteger(1000)
+
+    init {
+        createNotificationChannel()
+    }
+
+    private fun createNotificationChannel() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val importance = NotificationManager.IMPORTANCE_DEFAULT
+            val channel = NotificationChannel(CHANNEL_ID, CHANNEL_NAME, importance).apply {
+                description = CHANNEL_DESCRIPTION
+            }
+            val manager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+            manager.createNotificationChannel(channel)
+        }
+    }
+
+    /**
+     * 실시간 체결 이벤트를 notification으로 표시
+     */
+    fun showTradeNotification(trade: RealTimeTrade, stockName: String? = null) {
+        val notificationManager = NotificationManagerCompat.from(context)
+        if (!notificationManager.areNotificationsEnabled()) return
+
+        val displayName = if (!stockName.isNullOrEmpty()) stockName else trade.code
+        val sign = if (trade.delta >= 0) "▲" else "▼"
+        val title = "$displayName $sign ${formatPrice(trade.price)}"
+        val body = buildString {
+            append("등락 ${formatRate(trade.rate)}%")
+            append("  |  ")
+            append("거래량 ${formatVolume(trade.volume)}")
+            append("  |  ")
+            append("체결 ${formatTime(trade.datetime)}")
+        }
+
+        val intent = Intent(context, MainActivity::class.java).apply {
+            flags = Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP
+            putExtra("code", trade.code)
+        }
+        val pendingIntent = PendingIntent.getActivity(
+            context,
+            trade.code.hashCode(),
+            intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+        )
+
+        val notification = NotificationCompat.Builder(context, CHANNEL_ID)
+            .setSmallIcon(R.drawable.ic_notification_trade)
+            .setContentTitle(title)
+            .setContentText(body)
+            .setAutoCancel(true)
+            .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+            .setContentIntent(pendingIntent)
+            .build()
+
+        notificationManager.notify(notificationIdCounter.getAndIncrement(), notification)
+    }
+
+    private fun formatPrice(price: Double): String {
+        return "%,.0f원".format(price)
+    }
+
+    private fun formatRate(rate: Double): String {
+        return "%.2f".format(rate)
+    }
+
+    private fun formatVolume(volume: Double): String {
+        return "%,.0f".format(volume)
+    }
+
+    /**
+     * HHmmss → HH:mm:ss
+     */
+    private fun formatTime(time: String): String {
+        if (time.length < 6) return time
+        return "${time.substring(0, 2)}:${time.substring(2, 4)}:${time.substring(4, 6)}"
+    }
+}

--- a/app/src/main/java/com/trueedu/project/notification/TradeNotificationWorker.kt
+++ b/app/src/main/java/com/trueedu/project/notification/TradeNotificationWorker.kt
@@ -1,0 +1,49 @@
+package com.trueedu.project.notification
+
+import android.util.Log
+import com.trueedu.project.data.StockPool
+import com.trueedu.project.data.realtime.WsMessageHandler
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * WsMessageHandler의 tradeSignal을 구독하여
+ * 실시간 체결 이벤트를 notification으로 표시하는 컴포넌트
+ */
+@Singleton
+class TradeNotificationWorker @Inject constructor(
+    private val wsMessageHandler: WsMessageHandler,
+    private val stockPool: StockPool,
+    private val tradeNotificationManager: TradeNotificationManager,
+) {
+    companion object {
+        private val TAG = TradeNotificationWorker::class.java.simpleName
+    }
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private var job: Job? = null
+
+    fun start() {
+        if (job?.isActive == true) return
+        Log.d(TAG, "start()")
+
+        job = scope.launch {
+            wsMessageHandler.tradeSignal.collect { trade ->
+                Log.d(TAG, "trade received: ${trade.code} ${trade.price}")
+                val stockName = stockPool.get(trade.code)?.nameKr
+                tradeNotificationManager.showTradeNotification(trade, stockName)
+            }
+        }
+    }
+
+    fun stop() {
+        Log.d(TAG, "stop()")
+        job?.cancel()
+        job = null
+    }
+}

--- a/app/src/main/res/drawable/ic_notification_trade.xml
+++ b/app/src/main/res/drawable/ic_notification_trade.xml
@@ -1,0 +1,23 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+    <!-- 차트 상승 아이콘 (단색 monochrome - notification 전용) -->
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M3,17 L7,13 L10,16 L14,10 L17,13 L21,7"
+        android:strokeWidth="2"
+        android:strokeColor="@android:color/white"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:fillType="nonZero" />
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M17,7 L21,7 L21,11"
+        android:strokeWidth="2"
+        android:strokeColor="@android:color/white"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round" />
+</vector>


### PR DESCRIPTION
## 개요
웹소켓으로 수신되는 실시간 체결 이벤트를 Android Notification으로 표시하는 기능을 추가했습니다.

## 변경 사항

### 신규 파일
- **`notification/TradeNotificationManager.kt`**
  - `trade_realtime` 채널 생성 (앱 최초 실행 시 자동 등록)
  - 체결 알림 내용: 종목명 + 현재가, 등락률 / 거래량 / 체결 시간
  - 알림 탭 시 `MainActivity`로 이동 (종목 코드 `code` extra 전달)
  - `NotificationManagerCompat.areNotificationsEnabled()` 체크 후 발송

- **`notification/TradeNotificationWorker.kt`**
  - `WsMessageHandler.tradeSignal`을 구독
  - 체결 이벤트 수신 시 `StockPool`에서 종목명 조회 후 알림 발송

### 수정 파일
- **`App.kt`**: `ON_START` / `ON_STOP` 시 `TradeNotificationWorker.start/stop` 연동
- **`MainActivity.kt`**: Android 13+ `POST_NOTIFICATIONS` 런타임 권한 요청
- **`AndroidManifest.xml`**: `POST_NOTIFICATIONS` 권한 선언 추가

## 동작 흐름
```
WsMessageHandler.tradeSignal
  → TradeNotificationWorker (collect)
    → StockPool.get(code)?.nameKr  (종목명 조회)
      → TradeNotificationManager.showTradeNotification()
```

## 테스트
- 빌드: `./gradlew :app:compileDebugKotlin` ✅