### PR TITLE
feat: NXT 시간대 실시간 체결가 수신 지원

### DIFF
--- a/app/src/main/java/com/trueedu/project/data/realtime/RealPriceManager.kt
+++ b/app/src/main/java/com/trueedu/project/data/realtime/RealPriceManager.kt
@@ -18,6 +18,7 @@ import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.launch
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
+import java.util.Calendar
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -32,6 +33,36 @@ class RealPriceManager @Inject constructor(
 
     companion object {
         private const val MAX_SIZE = 20 // 최대 20개의 요청 가능
+
+        /**
+         * 현재 시각이 NXT 거래 시간대인지 확인
+         *
+         * NXT 운영 시간:
+         *   - 오전 8:00 ~ 9:00 (KRX 장 시작 전)
+         *   - 오후 3:30 ~ 8:00 (KRX 장 마감 후)
+         */
+        fun isNxtTradingHour(): Boolean {
+            val cal = Calendar.getInstance()
+            val hour = cal.get(Calendar.HOUR_OF_DAY)
+            val minute = cal.get(Calendar.MINUTE)
+            val totalMinutes = hour * 60 + minute
+
+            val morningStart = 8 * 60       // 08:00
+            val morningEnd = 9 * 60         // 09:00
+            val afternoonStart = 15 * 60 + 30  // 15:30
+            val afternoonEnd = 20 * 60      // 20:00
+
+            return totalMinutes in morningStart until morningEnd ||
+                    totalMinutes in afternoonStart until afternoonEnd
+        }
+
+        fun currentTradeTransactionId(): TransactionId {
+            return if (isNxtTradingHour()) {
+                TransactionId.RealTimeTradeNxt
+            } else {
+                TransactionId.RealTimeTrade
+            }
+        }
     }
 
     private var job: Job? = null
@@ -60,7 +91,10 @@ class RealPriceManager @Inject constructor(
             }
             launch {
                 wsMessageHandler.observeEvent()
-                    .filter { it.header.transactionId == TransactionId.RealTimeTrade }
+                    .filter {
+                        it.header.transactionId == TransactionId.RealTimeTrade ||
+                        it.header.transactionId == TransactionId.RealTimeTradeNxt
+                    }
                     .collect {
                         if (it.body?.returnCode != "0") return@collect
                         val code = it.body.transactionKey ?: return@collect
@@ -171,6 +205,9 @@ class RealPriceManager @Inject constructor(
      * 요청을 위한 json 데이터 만들기
      * @param code: 종목 코드
      * @param subscribe: true - 구독, false - 해지
+     *
+     * NXT 운영 시간(08:00~09:00, 15:30~20:00)에는 H0NXCNT0 를 사용하고,
+     * 그 외 KRX 정규장 시간에는 H0STCNT0 를 사용한다.
      */
     private fun makeRequest(code: String, subscribe: Boolean): String {
         val transactionType = if (subscribe) "1" else "2"
@@ -182,7 +219,7 @@ class RealPriceManager @Inject constructor(
             contentType = "utf-8",
         )
         val input = WsRequestBodyInput(
-            transactionId = TransactionId.RealTimeTrade,
+            transactionId = currentTradeTransactionId(),
             transactionKey = code,
         )
         val body = WsRequestBody(input)

--- a/app/src/main/java/com/trueedu/project/data/realtime/WsMessageHandler.kt
+++ b/app/src/main/java/com/trueedu/project/data/realtime/WsMessageHandler.kt
@@ -116,7 +116,8 @@ class WsMessageHandler @Inject constructor(
                     when (res.header.transactionId) {
                         TransactionId.PingPong -> webSocketService.sendMessage(text)
                         TransactionId.RealTimeQuotes,
-                        TransactionId.RealTimeTrade -> {
+                        TransactionId.RealTimeTrade,
+                        TransactionId.RealTimeTradeNxt -> {
                             CoroutineScope(Dispatchers.IO).launch {
                                 event.emit(res)
                             }
@@ -156,7 +157,8 @@ class WsMessageHandler @Inject constructor(
                     quotesSignal.emit(dto)
                 }
             }
-            TransactionId.RealTimeTrade -> {
+            TransactionId.RealTimeTrade,
+            TransactionId.RealTimeTradeNxt -> {
                 val dto = RealTimeTrade.from(data)
                 MainScope().launch {
                     tradeSignal.emit(dto)

--- a/app/src/main/java/com/trueedu/project/model/ws/TransactionId.kt
+++ b/app/src/main/java/com/trueedu/project/model/ws/TransactionId.kt
@@ -8,9 +8,11 @@ enum class TransactionId(val value: String) {
     @SerialName("PINGPONG")
     PingPong("PINGPONG"),
     @SerialName("H0STASP0")
-    RealTimeQuotes("H0STASP0"), // 실시간 호가
+    RealTimeQuotes("H0STASP0"), // 실시간 호가 (KRX)
     @SerialName("H0STCNT0")
-    RealTimeTrade("H0STCNT0"), // 실시간 체결
+    RealTimeTrade("H0STCNT0"), // 실시간 체결 (KRX)
+    @SerialName("H0NXCNT0")
+    RealTimeTradeNxt("H0NXCNT0"), // 실시간 체결 (NXT)
     @SerialName("H0STCNI0")
     TradeNotification("H0STCNI0"), // 체결 통보
 }


### PR DESCRIPTION
## 개요
NXT(넥스트레이드) 운영 시간에는 KIS 웹소켓 TR `H0NXCNT0`를 사용하고,
KRX 정규장 시간에는 기존 `H0STCNT0`를 사용하도록 변경합니다.

## NXT 운영 시간
| 시간대 | 시작 | 종료 | TR ID |
|--------|------|------|-------|
| KRX 장 시작 전 | 08:00 | 09:00 | `H0NXCNT0` |
| KRX 장 중 | 09:00 | 15:30 | `H0STCNT0` |
| KRX 장 마감 후 | 15:30 | 20:00 | `H0NXCNT0` |

## 변경 파일
- `model/ws/TransactionId.kt` — `RealTimeTradeNxt(H0NXCNT0)` 추가
- `data/realtime/RealPriceManager.kt` — `isNxtTradingHour()` / `currentTradeTransactionId()` 추가, `makeRequest()`에서 시간대별 TR ID 자동 선택
- `data/realtime/WsMessageHandler.kt` — `RealTimeTradeNxt` 메시지 수신 처리 추가

## 참고
- NXT 체결 데이터 포맷(`H0NXCNT0`)은 KRX(`H0STCNT0`)와 동일하므로 `RealTimeTrade.from()` 파싱 변경 없음
- 구독 취소(`cancelRequests`) 시에도 동일한 로직으로 현재 시간대 TR ID 사용