### PR TITLE
feat: NXT 시간대 실시간 호가 수신 지원

### DIFF
--- a/app/src/main/java/com/trueedu/project/data/realtime/RealOrderManager.kt
+++ b/app/src/main/java/com/trueedu/project/data/realtime/RealOrderManager.kt
@@ -24,6 +24,22 @@ class RealOrderManager @Inject constructor(
     private val local: Local,
     private val wsMessageHandler: WsMessageHandler
 ) {
+    companion object {
+        /**
+         * 현재 시각 기준 호가 TransactionId 반환
+         *
+         * NXT 운영 시간(08:00~09:00, 15:30~20:00)에는 H0NXASP0 (NXT 호가),
+         * 그 외에는 H0STASP0 (KRX 호가) 사용
+         */
+        fun currentQuotesTransactionId(): TransactionId {
+            return if (RealPriceManager.isNxtTradingHour()) {
+                TransactionId.RealTimeQuotesNxt
+            } else {
+                TransactionId.RealTimeQuotes
+            }
+        }
+    }
+
     private var job: Job? = null
 
     // 현재 처리중인 종목 코드
@@ -35,7 +51,10 @@ class RealOrderManager @Inject constructor(
         job = MainScope().launch(Dispatchers.IO) {
             launch {
                 wsMessageHandler.observeEvent()
-                    .filter { it.header.transactionId == TransactionId.RealTimeQuotes }
+                    .filter {
+                        it.header.transactionId == TransactionId.RealTimeQuotes ||
+                        it.header.transactionId == TransactionId.RealTimeQuotesNxt
+                    }
                     .collect {
                         it.body
                         logD(it.toString())
@@ -76,6 +95,9 @@ class RealOrderManager @Inject constructor(
      * 요청을 위한 json 데이터 만들기
      * @param code: 종목 코드
      * @param subscribe: true - 구독, false - 해지
+     *
+     * NXT 운영 시간(08:00~09:00, 15:30~20:00)에는 H0NXASP0 를 사용하고,
+     * 그 외 KRX 정규장 시간에는 H0STASP0 를 사용한다.
      */
     private fun makeRequest(code: String, subscribe: Boolean): String {
         val transactionType = if (subscribe) "1" else "2"
@@ -87,7 +109,7 @@ class RealOrderManager @Inject constructor(
             contentType = "utf-8",
         )
         val input = WsRequestBodyInput(
-            transactionId = TransactionId.RealTimeQuotes,
+            transactionId = currentQuotesTransactionId(),
             transactionKey = code,
         )
         val body = WsRequestBody(input)

--- a/app/src/main/java/com/trueedu/project/data/realtime/WsMessageHandler.kt
+++ b/app/src/main/java/com/trueedu/project/data/realtime/WsMessageHandler.kt
@@ -116,6 +116,7 @@ class WsMessageHandler @Inject constructor(
                     when (res.header.transactionId) {
                         TransactionId.PingPong -> webSocketService.sendMessage(text)
                         TransactionId.RealTimeQuotes,
+                        TransactionId.RealTimeQuotesNxt,
                         TransactionId.RealTimeTrade,
                         TransactionId.RealTimeTradeNxt -> {
                             CoroutineScope(Dispatchers.IO).launch {
@@ -151,7 +152,8 @@ class WsMessageHandler @Inject constructor(
         val transactionId = TransactionId.entries.firstOrNull { it.value == org[1] }
         val data = org[3]
         when (transactionId) {
-            TransactionId.RealTimeQuotes -> {
+            TransactionId.RealTimeQuotes,
+            TransactionId.RealTimeQuotesNxt -> {
                 val dto = RealTimeOrder.from(data)
                 MainScope().launch {
                     quotesSignal.emit(dto)

--- a/app/src/main/java/com/trueedu/project/model/ws/TransactionId.kt
+++ b/app/src/main/java/com/trueedu/project/model/ws/TransactionId.kt
@@ -9,6 +9,8 @@ enum class TransactionId(val value: String) {
     PingPong("PINGPONG"),
     @SerialName("H0STASP0")
     RealTimeQuotes("H0STASP0"), // 실시간 호가 (KRX)
+    @SerialName("H0NXASP0")
+    RealTimeQuotesNxt("H0NXASP0"), // 실시간 호가 (NXT)
     @SerialName("H0STCNT0")
     RealTimeTrade("H0STCNT0"), // 실시간 체결 (KRX)
     @SerialName("H0NXCNT0")


### PR DESCRIPTION
## 변경 사항

실시간 호가(RealOrderManager)에서 KRX/NXT 거래소를 시간 기반으로 자동 분기합니다.

### 배경
- 기존 실시간 체결(RealPriceManager)은 NXT 시간대에 H0NXCNT0를 사용하도록 분기되어 있었으나,
  실시간 호가(RealOrderManager)는 항상 H0STASP0(KRX)만 사용하고 있었음
- NXT 운영 시간(08:00~09:00, 15:30~20:00)에는 H0NXASP0(NXT 호가)를 사용해야 함

### 수정 내용

**`TransactionId.kt`**
- `RealTimeQuotesNxt(H0NXASP0)` 추가 — NXT 실시간 호가 트랜잭션 ID

**`WsMessageHandler.kt`**
- `RealTimeQuotesNxt` 이벤트를 system message 처리 및 실시간 데이터 파싱에 포함

**`RealOrderManager.kt`**
- `currentQuotesTransactionId()` 메서드 추가: `RealPriceManager.isNxtTradingHour()` 재사용
  - NXT 시간대 → `H0NXASP0`
  - KRX 시간대 → `H0STASP0`
- `start()`의 이벤트 필터에 `RealTimeQuotesNxt` 추가
- `makeRequest()`에서 시간 기반으로 올바른 TransactionId 사용

### 시간 분기 기준 (RealPriceManager와 동일)
| 시간대 | 거래소 | TransactionId |
|--------|--------|---------------|
| 08:00 ~ 09:00 | NXT | H0NXASP0 |
| 09:00 ~ 15:30 | KRX | H0STASP0 |
| 15:30 ~ 20:00 | NXT | H0NXASP0 |
| 그 외 | KRX | H0STASP0 |
