### PR TITLE
refactor: Screen 클래스를 top-level Composable 함수로 전환

### DIFF
--- a/app/src/main/java/com/trueedu/project/MainActivity.kt
+++ b/app/src/main/java/com/trueedu/project/MainActivity.kt
@@ -18,7 +18,6 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.snapshotFlow
 import androidx.lifecycle.lifecycleScope
-import androidx.navigation.NavBackStackEntry
 import com.trueedu.project.analytics.TrueAnalytics
 import com.trueedu.project.broadcast.DownloadCompleteReceiver
 import com.trueedu.project.data.DartManager
@@ -29,7 +28,6 @@ import com.trueedu.project.data.StockPool
 import com.trueedu.project.data.TokenKeyManager
 import com.trueedu.project.data.log.logD
 import com.trueedu.project.data.realtime.WsMessageHandler
-import com.trueedu.project.data.spac.SpacManager
 import com.trueedu.project.model.dto.firebase.AppNotice
 import com.trueedu.project.repository.local.Local
 import com.trueedu.project.repository.remote.AuthRemote
@@ -40,18 +38,9 @@ import com.trueedu.project.ui.common.PopupType
 import com.trueedu.project.ui.main.MainNavigation
 import com.trueedu.project.ui.main.MainScreen
 import com.trueedu.project.ui.theme.TrueProjectTheme
-import com.trueedu.project.ui.views.UserInfoViewModel
 import com.trueedu.project.ui.views.home.AppNoticePopup
 import com.trueedu.project.ui.views.home.BottomNavItem
-import com.trueedu.project.ui.views.home.BottomNavScreen
 import com.trueedu.project.ui.views.home.ForceUpdateView
-import com.trueedu.project.ui.views.home.HomeScreen
-import com.trueedu.project.ui.navigation.bottomNavItemOrNull
-import com.trueedu.project.ui.views.menu.MenuScreen
-import com.trueedu.project.ui.views.spac.SpacScreen
-import com.trueedu.project.ui.views.spac.SpacViewModel
-import com.trueedu.project.ui.views.watch.WatchListViewModel
-import com.trueedu.project.ui.views.watch.WatchScreen
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
@@ -76,8 +65,6 @@ class MainActivity : AppCompatActivity() {
     @Inject
     lateinit var downloadCompleteReceiver: DownloadCompleteReceiver
     @Inject
-    lateinit var spacManager: SpacManager
-    @Inject
     lateinit var dartManager: DartManager
     @Inject
     lateinit var remoteConfig: RemoteConfig
@@ -88,14 +75,6 @@ class MainActivity : AppCompatActivity() {
     lateinit var wsMessageHandler: WsMessageHandler
 
     private val vm by viewModels<MainViewModel>()
-    private val watchVm by viewModels<WatchListViewModel>()
-    private val spacVm by viewModels<SpacViewModel>()
-    private val homeDrawerVm by viewModels<UserInfoViewModel>()
-
-    private lateinit var homeScreen: HomeScreen
-    private lateinit var watchScreen: WatchScreen
-    private lateinit var spacScreen: SpacScreen
-    private lateinit var menuScreen: MenuScreen
 
     private var openDrawer: (() -> Unit)? = null
 
@@ -157,41 +136,6 @@ class MainActivity : AppCompatActivity() {
 
         enableEdgeToEdge()
 
-        homeScreen = HomeScreen(
-            activity = this,
-            vm = vm,
-            stockPool = stockPool,
-            admobManager = admobManager,
-            remoteConfig = remoteConfig,
-            trueAnalytics = trueAnalytics,
-            fragmentManager = supportFragmentManager,
-            onUserInfo = ::onUserInfo,
-        )
-        watchScreen = WatchScreen(
-            activity = this,
-            vm = watchVm,
-            admobManager = admobManager,
-            remoteConfig = remoteConfig,
-            trueAnalytics = trueAnalytics,
-            fragmentManager = supportFragmentManager,
-        )
-        spacScreen = SpacScreen(
-            mainVm = vm,
-            vm = spacVm,
-            spacManager = spacManager,
-            trueAnalytics = trueAnalytics,
-            remoteConfig = remoteConfig,
-            admobManager = admobManager,
-            fragmentManager = supportFragmentManager,
-        )
-        menuScreen = MenuScreen(
-            screen = screen,
-            trueAnalytics = trueAnalytics,
-            tokenKeyManager = tokenKeyManager,
-            dartManager = dartManager,
-            fragmentManager = supportFragmentManager,
-        )
-
         // Register the onBackPressed callback
         val onBackPressedCallback = object : OnBackPressedCallback(true) {
             override fun handleOnBackPressed() {
@@ -233,11 +177,9 @@ class MainActivity : AppCompatActivity() {
                     MainScreen(
                         activity = this,
                         googleAccount = googleAccount,
-                        homeDrawerVm = homeDrawerVm,
                         trueAnalytics = trueAnalytics,
                         fragmentManager = supportFragmentManager,
                         wsMessageHandler = wsMessageHandler,
-                        screenOf = ::screenOf,
                         getLastBackgroundTime = { lastBackgroundElapsedRealtime },
                         setLastBackgroundTime = { lastBackgroundElapsedRealtime = it },
                         setOpenDrawer = { openDrawer = it },
@@ -251,25 +193,20 @@ class MainActivity : AppCompatActivity() {
                             MainNavigation(
                                 navController = navController,
                                 innerPadding = innerPadding,
-                                homeScreen = homeScreen,
-                                watchScreen = watchScreen,
-                                spacScreen = spacScreen,
-                                menuScreen = menuScreen,
+                                fragmentManager = supportFragmentManager,
+                                stockPool = stockPool,
+                                admobManager = admobManager,
+                                remoteConfig = remoteConfig,
+                                trueAnalytics = trueAnalytics,
+                                screen = screen,
+                                tokenKeyManager = tokenKeyManager,
+                                dartManager = dartManager,
+                                onUserInfo = ::onUserInfo,
                             )
                         },
                     )
                 }
             }
-        }
-    }
-
-    private fun screenOf(entry: NavBackStackEntry): BottomNavScreen? {
-        return when (entry.bottomNavItemOrNull()) {
-            BottomNavItem.Home -> homeScreen
-            BottomNavItem.Watch -> watchScreen
-            BottomNavItem.Spac -> spacScreen
-            BottomNavItem.Menu -> menuScreen
-            null -> null
         }
     }
 

--- a/app/src/main/java/com/trueedu/project/ui/main/MainNavigation.kt
+++ b/app/src/main/java/com/trueedu/project/ui/main/MainNavigation.kt
@@ -4,9 +4,17 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.fragment.app.FragmentManager
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
+import com.trueedu.project.analytics.TrueAnalytics
+import com.trueedu.project.data.RemoteConfig
+import com.trueedu.project.data.ScreenControl
+import com.trueedu.project.data.StockPool
+import com.trueedu.project.data.TokenKeyManager
+import com.trueedu.project.data.DartManager
+import com.trueedu.project.ui.ads.AdmobManager
 import com.trueedu.project.ui.views.home.BottomNavItem
 import com.trueedu.project.ui.views.home.HomeScreen
 import com.trueedu.project.ui.views.menu.MenuScreen
@@ -18,10 +26,15 @@ import com.trueedu.project.ui.views.watch.WatchScreen
 fun MainNavigation(
     navController: NavHostController,
     innerPadding: PaddingValues,
-    homeScreen: HomeScreen,
-    watchScreen: WatchScreen,
-    spacScreen: SpacScreen,
-    menuScreen: MenuScreen,
+    fragmentManager: FragmentManager,
+    stockPool: StockPool,
+    admobManager: AdmobManager,
+    remoteConfig: RemoteConfig,
+    trueAnalytics: TrueAnalytics,
+    screen: ScreenControl,
+    tokenKeyManager: TokenKeyManager,
+    dartManager: DartManager,
+    onUserInfo: () -> Unit,
 ) {
     NavHost(
         navController = navController,
@@ -29,16 +42,39 @@ fun MainNavigation(
         modifier = Modifier.padding(innerPadding),
     ) {
         composable<BottomNavItem.Home> {
-            homeScreen.Draw()
+            HomeScreen(
+                stockPool = stockPool,
+                admobManager = admobManager,
+                remoteConfig = remoteConfig,
+                trueAnalytics = trueAnalytics,
+                fragmentManager = fragmentManager,
+                onUserInfo = onUserInfo,
+            )
         }
         composable<BottomNavItem.Watch> {
-            watchScreen.Draw()
+            WatchScreen(
+                admobManager = admobManager,
+                remoteConfig = remoteConfig,
+                trueAnalytics = trueAnalytics,
+                fragmentManager = fragmentManager,
+            )
         }
         composable<BottomNavItem.Spac> {
-            spacScreen.Draw()
+            SpacScreen(
+                trueAnalytics = trueAnalytics,
+                remoteConfig = remoteConfig,
+                admobManager = admobManager,
+                fragmentManager = fragmentManager,
+            )
         }
         composable<BottomNavItem.Menu> {
-            menuScreen.Draw()
+            MenuScreen(
+                screen = screen,
+                trueAnalytics = trueAnalytics,
+                tokenKeyManager = tokenKeyManager,
+                dartManager = dartManager,
+                fragmentManager = fragmentManager,
+            )
         }
     }
 }

--- a/app/src/main/java/com/trueedu/project/ui/main/MainScreen.kt
+++ b/app/src/main/java/com/trueedu/project/ui/main/MainScreen.kt
@@ -14,11 +14,14 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.platform.LocalContext
 import androidx.fragment.app.FragmentManager
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import androidx.navigation.NavBackStackEntry
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
@@ -31,7 +34,6 @@ import com.trueedu.project.data.realtime.WsMessageHandler
 import com.trueedu.project.ui.dev.OnOffState
 import com.trueedu.project.ui.views.UserInfoViewModel
 import com.trueedu.project.ui.views.home.BottomNavItem
-import com.trueedu.project.ui.views.home.BottomNavScreen
 import com.trueedu.project.ui.views.home.HomeBottomNavigation
 import com.trueedu.project.ui.views.home.HomeDrawer
 import com.trueedu.project.ui.navigation.bottomNavItemOrNull
@@ -42,53 +44,44 @@ import kotlinx.coroutines.launch
 fun MainScreen(
     activity: MainActivity,
     googleAccount: GoogleAccount,
-    homeDrawerVm: UserInfoViewModel,
     trueAnalytics: TrueAnalytics,
     fragmentManager: FragmentManager,
     wsMessageHandler: WsMessageHandler,
-    screenOf: (NavBackStackEntry) -> BottomNavScreen?,
     getLastBackgroundTime: () -> Long,
     setLastBackgroundTime: (Long) -> Unit,
     setOpenDrawer: ((() -> Unit)?) -> Unit,
     onSessionExpired: () -> Unit,
     mainNavigation: @Composable (navController: NavHostController, innerPadding: PaddingValues) -> Unit,
+    homeDrawerVm: UserInfoViewModel = hiltViewModel(LocalContext.current as ComponentActivity),
 ) {
     val navController = rememberNavController()
     val navBackStackEntry by navController.currentBackStackEntryAsState()
     var currentTab by remember { mutableStateOf<BottomNavItem?>(BottomNavItem.Home) }
     currentTab = navBackStackEntry.bottomNavItemOrNull() ?: currentTab
 
-    val lifecycleObserver = remember {
-        LifecycleEventObserver { owner, event ->
-            if (owner !is NavBackStackEntry) return@LifecycleEventObserver
-            val screen = screenOf(owner) ?: return@LifecycleEventObserver
+    val lifecycleOwner = LocalLifecycleOwner.current
 
+    // 30분 세션 만료 체크를 navBackStackEntry lifecycle 변화로 처리
+    DisposableEffect(navBackStackEntry) {
+        val observer = LifecycleEventObserver { owner, event ->
             when (event) {
                 Lifecycle.Event.ON_START -> {
                     val currentTime = SystemClock.elapsedRealtime()
                     val elapsedTime = currentTime - getLastBackgroundTime()
-
                     logD("elapsedTime: $elapsedTime")
-                    if (elapsedTime >= 30 * 60 * 1000) { // 30 minutes
+                    if (elapsedTime >= 30 * 60 * 1000) {
                         onSessionExpired()
-                    } else {
-                        screen.onStart()
                     }
                 }
                 Lifecycle.Event.ON_STOP -> {
-                    screen.onStop()
                     setLastBackgroundTime(SystemClock.elapsedRealtime())
                 }
                 else -> Unit
             }
         }
-    }
-
-    // Lifecycle observer 등록 및 해제
-    DisposableEffect(navBackStackEntry) {
-        navBackStackEntry?.lifecycle?.addObserver(lifecycleObserver)
+        navBackStackEntry?.lifecycle?.addObserver(observer)
         onDispose {
-            navBackStackEntry?.lifecycle?.removeObserver(lifecycleObserver)
+            navBackStackEntry?.lifecycle?.removeObserver(observer)
         }
     }
 
@@ -133,4 +126,3 @@ fun MainScreen(
         OnOffState(wsMessageHandler.on.value)
     }
 }
-

--- a/app/src/main/java/com/trueedu/project/ui/views/home/HomeScreen.kt
+++ b/app/src/main/java/com/trueedu/project/ui/views/home/HomeScreen.kt
@@ -1,6 +1,5 @@
 package com.trueedu.project.ui.views.home
 
-import android.app.Activity
 import android.widget.Toast
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.exclude
@@ -13,14 +12,20 @@ import androidx.compose.material3.NavigationBarDefaults
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.ScaffoldDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
+import androidx.activity.ComponentActivity
 import androidx.fragment.app.FragmentManager
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import com.trueedu.project.MainViewModel
 import com.trueedu.project.analytics.TrueAnalytics
 import com.trueedu.project.data.RemoteConfig
 import com.trueedu.project.data.StockPool
-import com.trueedu.project.data.log.logD
 import com.trueedu.project.model.dto.firebase.StockInfo
 import com.trueedu.project.ui.ads.AdmobManager
 import com.trueedu.project.ui.ads.NativeAdView
@@ -32,121 +37,120 @@ import com.trueedu.project.ui.views.order.OrderFragment
 import com.trueedu.project.ui.views.search.StockSearchFragment
 import com.trueedu.project.ui.views.setting.AppKeyInputFragment
 
-class HomeScreen(
-    private val activity: Activity,
-    private val vm: MainViewModel,
-    private val stockPool: StockPool,
-    private val admobManager: AdmobManager,
-    private val remoteConfig: RemoteConfig,
-    private val trueAnalytics: TrueAnalytics,
-    private val fragmentManager: FragmentManager,
-    private val onUserInfo: () -> Unit,
-): BottomNavScreen {
-    @Composable
-    override fun Draw() {
-        Scaffold(
-            topBar = {
-                MainTopBar(
-                    vm.googleSignInAccount.value,
-                    vm.accountNum.value,
-                    onUserInfo,
-                    ::onAccountInfo,
-                    ::onSearch,
-                )
-            },
-            contentWindowInsets =
-                ScaffoldDefaults.contentWindowInsets.exclude(NavigationBarDefaults.windowInsets),
-            modifier = Modifier.fillMaxSize()
-        ) { innerPadding ->
+@Composable
+fun HomeScreen(
+    stockPool: StockPool,
+    admobManager: AdmobManager,
+    remoteConfig: RemoteConfig,
+    trueAnalytics: TrueAnalytics,
+    fragmentManager: FragmentManager,
+    onUserInfo: () -> Unit,
+    vm: MainViewModel = hiltViewModel(LocalContext.current as ComponentActivity),
+) {
+    val context = LocalContext.current
+    val lifecycleOwner = LocalLifecycleOwner.current
 
-            if (vm.loading.value) {
-                LoadingView()
-                return@Scaffold
-            }
-
-            val state = rememberLazyListState()
-            LazyColumn(
-                state = state,
-                contentPadding = PaddingValues(top = 8.dp),
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(innerPadding)
-            ) {
-                vm.userStocks.value?.output2?.firstOrNull()?.let {
-                    item {
-                        AccountInfo(
-                            it,
-                            vm.marketPriceMode.value,
-                            ::onRefresh,
-                            vm::onChangeMarketPriceMode
-                        )
-                    }
-                } ?: item {
-                    Margin(32)
-                    EmptyHome()
+    DisposableEffect(lifecycleOwner) {
+        val observer = LifecycleEventObserver { _, event ->
+            when (event) {
+                Lifecycle.Event.ON_START -> {
+                    trueAnalytics.log("home__enter")
                 }
+                else -> Unit
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose {
+            lifecycleOwner.lifecycle.removeObserver(observer)
+        }
+    }
 
-                vm.userStocks.value?.output1?.let {
-                    val items = it.filter { it.holdingQuantity.toDouble() > 0 }
-                    // 광고
-                    if (remoteConfig.adVisible.value && admobManager.nativeAd.value != null) {
-                        item { NativeAdView(admobManager.nativeAd.value!!) }
-                    }
-                    itemsIndexed(items, { _, item -> item.code} ) { _, item ->
-                        val stock = stockPool.get(item.code)
-                        HomeStockItem(item, stock, vm.marketPriceMode.value, ::onPriceClick) {
-                            stockPool.get(item.code)?.let {
-                                onItemClick(it)
+    Scaffold(
+        topBar = {
+            MainTopBar(
+                googleAccount = vm.googleSignInAccount.value,
+                accountNum = vm.accountNum.value,
+                onUserInfoClick = onUserInfo,
+                onAccountInfoClick = {
+                    trueAnalytics.clickButton("home__account_info__click")
+                    AppKeyInputFragment.show(false, fragmentManager)
+                },
+                onSearchClick = {
+                    trueAnalytics.clickButton("home__stock_search__click")
+                    StockSearchFragment.show(null, fragmentManager)
+                },
+            )
+        },
+        contentWindowInsets =
+            ScaffoldDefaults.contentWindowInsets.exclude(NavigationBarDefaults.windowInsets),
+        modifier = Modifier.fillMaxSize()
+    ) { innerPadding ->
+
+        if (vm.loading.value) {
+            LoadingView()
+            return@Scaffold
+        }
+
+        val state = rememberLazyListState()
+        LazyColumn(
+            state = state,
+            contentPadding = PaddingValues(top = 8.dp),
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding)
+        ) {
+            vm.userStocks.value?.output2?.firstOrNull()?.let {
+                item {
+                    AccountInfo(
+                        it,
+                        vm.marketPriceMode.value,
+                        onRefresh = {
+                            trueAnalytics.clickButton("home__refresh__click")
+                            vm.refresh {
+                                Toast.makeText(
+                                    context,
+                                    "자산 정보를 갱신했습니다.",
+                                    Toast.LENGTH_SHORT
+                                ).show()
                             }
-                        }
-                    }
+                        },
+                        vm::onChangeMarketPriceMode
+                    )
+                }
+            } ?: item {
+                Margin(32)
+                EmptyHome()
+            }
+
+            vm.userStocks.value?.output1?.let {
+                val items = it.filter { it.holdingQuantity.toDouble() > 0 }
+                // 광고
+                if (remoteConfig.adVisible.value && admobManager.nativeAd.value != null) {
+                    item { NativeAdView(admobManager.nativeAd.value!!) }
+                }
+                itemsIndexed(items, { _, item -> item.code} ) { _, item ->
+                    val stock = stockPool.get(item.code)
+                    HomeStockItem(
+                        item = item,
+                        stock = stock,
+                        marketPriceMode = vm.marketPriceMode.value,
+                        onPriceClick = { code ->
+                            trueAnalytics.clickButton("home__price__click")
+                            if (stockPool.get(code) == null) {
+                                Toast.makeText(context, "상장 폐지 종목입니다", Toast.LENGTH_SHORT).show()
+                                return@HomeStockItem
+                            }
+                            OrderFragment.show(code, fragmentManager)
+                        },
+                        onItemClick = { code ->
+                            stockPool.get(code)?.let { stockInfo ->
+                                trueAnalytics.clickButton("home__item__click")
+                                StockDetailFragment.show(stockInfo, fragmentManager)
+                            }
+                        },
+                    )
                 }
             }
-        }
-    }
-
-    override fun onStart() {
-        trueAnalytics.log("${screenName()}__enter")
-        logD("onStart")
-    }
-
-    override fun onStop() {
-        logD("onStop")
-    }
-
-    private fun onItemClick(stockInfo: StockInfo) {
-        trueAnalytics.clickButton("${screenName()}__item__click")
-        StockDetailFragment.show(stockInfo, fragmentManager)
-    }
-
-    private fun onAccountInfo() {
-        trueAnalytics.clickButton("${screenName()}__account_info__click")
-        AppKeyInputFragment.show(false, fragmentManager)
-    }
-
-    private fun onSearch() {
-        trueAnalytics.clickButton("${screenName()}__stock_search__click")
-        StockSearchFragment.show(null, fragmentManager)
-    }
-
-    private fun onPriceClick(code: String) {
-        trueAnalytics.clickButton("${screenName()}__price__click")
-        if (stockPool.get(code) == null) {
-            // 상장 폐지 종목이라서 주문으로 이동 안 함
-            Toast.makeText(activity.applicationContext, "상장 폐지 종목입니다", Toast.LENGTH_SHORT).show()
-            return
-        }
-        OrderFragment.show(code, fragmentManager)
-    }
-
-    private fun onRefresh() {
-        trueAnalytics.clickButton("${screenName()}__refresh__click")
-        vm.refresh {
-            Toast.makeText(
-                activity.applicationContext,
-                "자산 정보를 갱신했습니다.",
-                Toast.LENGTH_SHORT
-            ).show()
         }
     }
 }

--- a/app/src/main/java/com/trueedu/project/ui/views/menu/MenuScreen.kt
+++ b/app/src/main/java/com/trueedu/project/ui/views/menu/MenuScreen.kt
@@ -43,98 +43,81 @@ import com.trueedu.project.ui.dart.DartListFragment
 import com.trueedu.project.ui.ranking.VolumeRankingFragment
 import com.trueedu.project.ui.spac.SpacScheduleFragment
 import com.trueedu.project.ui.theme.TrueProjectTheme
-import com.trueedu.project.ui.views.home.BottomNavScreen
 import com.trueedu.project.ui.views.rights.ObservingRightsFragment
 import com.trueedu.project.ui.views.schedule.OrderScheduleFragment
 import com.trueedu.project.ui.views.setting.SettingFragment
 
-class MenuScreen(
-    private val screen: ScreenControl,
-    private val trueAnalytics: TrueAnalytics,
-    private val tokenKeyManager: TokenKeyManager,
-    private val dartManager: DartManager,
-    private val fragmentManager: FragmentManager,
-): BottomNavScreen {
-    @Composable
-    override fun Draw() {
-        TrueProjectTheme(
-            n = screen.theme.intValue,
-            forceDark = screen.forceDark.value
-        ) {
-            Scaffold(
-                topBar = {
-                    BackTitleTopBar(
-                        "메뉴",
-                        onBack = null,
-                        actionIcon = Icons.Outlined.Settings,
-                        onAction = ::onSettings,
-                    )
-                },
-                contentWindowInsets =
-                    ScaffoldDefaults.contentWindowInsets.exclude(NavigationBarDefaults.windowInsets),
+@Composable
+fun MenuScreen(
+    screen: ScreenControl,
+    trueAnalytics: TrueAnalytics,
+    tokenKeyManager: TokenKeyManager,
+    dartManager: DartManager,
+    fragmentManager: FragmentManager,
+) {
+    TrueProjectTheme(
+        n = screen.theme.intValue,
+        forceDark = screen.forceDark.value
+    ) {
+        Scaffold(
+            topBar = {
+                BackTitleTopBar(
+                    "메뉴",
+                    onBack = null,
+                    actionIcon = Icons.Outlined.Settings,
+                    onAction = {
+                        trueAnalytics.clickButton("menu__setting__click")
+                        SettingFragment.show(fragmentManager)
+                    },
+                )
+            },
+            contentWindowInsets =
+                ScaffoldDefaults.contentWindowInsets.exclude(NavigationBarDefaults.windowInsets),
+            modifier = Modifier
+                .fillMaxSize()
+                .background(color = MaterialTheme.colorScheme.background),
+        ) { innerPadding ->
+            Column(
                 modifier = Modifier
                     .fillMaxSize()
-                    .background(color = MaterialTheme.colorScheme.background),
-            ) { innerPadding ->
-                Column(
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .padding(innerPadding)
-                ) {
-                    if (tokenKeyManager.userKey.value != null) {
-                        MenuItem(Icons.Outlined.Timer, "예약 매매", ::onOrderSchedule)
-                        MenuItem(Icons.Outlined.Sync, "권리 현황", ::onObservingRights)
+                    .padding(innerPadding)
+            ) {
+                if (tokenKeyManager.userKey.value != null) {
+                    MenuItem(Icons.Outlined.Timer, "예약 매매") {
+                        trueAnalytics.clickButton("menu__order_schedule__click")
+                        OrderScheduleFragment.show(fragmentManager)
                     }
+                    MenuItem(Icons.Outlined.Sync, "권리 현황") {
+                        trueAnalytics.clickButton("menu__observing_rights__click")
+                        ObservingRightsFragment.show(fragmentManager)
+                    }
+                }
 
-                    val dartCount = dartManager.getSize().let {
-                        if (it == 0) "" else " ($it)"
+                val dartCount = dartManager.getSize().let {
+                    if (it == 0) "" else " ($it)"
+                }
+                MenuItem(Icons.Outlined.QueryStats, "스팩 공시${dartCount}") {
+                    trueAnalytics.clickButton("menu__spac_dart_list__click")
+                    DartListFragment.show(fragmentManager)
+                }
+                MenuItem(Icons.Outlined.CalendarMonth, "스팩 일정") {
+                    trueAnalytics.clickButton("menu__spac_schedule__click")
+                    SpacScheduleFragment.show(fragmentManager)
+                }
+                if (BuildConfig.DEBUG && tokenKeyManager.userKey.value != null) {
+                    MenuItem(Icons.Outlined.TrendingUp, "거래량 상위 종목") {
+                        trueAnalytics.clickButton("menu__volume_ranking__click")
+                        VolumeRankingFragment.show(fragmentManager)
                     }
-                    MenuItem(Icons.Outlined.QueryStats, "스팩 공시${dartCount}", ::onDartList)
-                    MenuItem(Icons.Outlined.CalendarMonth, "스팩 일정", ::onSpacSchedule)
-                    if (BuildConfig.DEBUG && tokenKeyManager.userKey.value != null) {
-                        MenuItem(Icons.Outlined.TrendingUp, "거래량 상위 종목", ::onVolumeRanking)
-                    }
-                    if (BuildConfig.DEBUG) {
-                        Margin(12)
-                        MenuItem(Icons.Outlined.Construction, "어드민 메뉴", ::onAdminMenu)
+                }
+                if (BuildConfig.DEBUG) {
+                    Margin(12)
+                    MenuItem(Icons.Outlined.Construction, "어드민 메뉴") {
+                        MyAdminFragment.show(fragmentManager)
                     }
                 }
             }
         }
-    }
-
-    private fun onSettings() {
-        trueAnalytics.clickButton("${screenName()}__setting__click")
-        SettingFragment.show(fragmentManager)
-    }
-
-    private fun onOrderSchedule() {
-        trueAnalytics.clickButton("${screenName()}__order_schedule__click")
-        OrderScheduleFragment.show(fragmentManager)
-    }
-
-    private fun onObservingRights() {
-        trueAnalytics.clickButton("${screenName()}__observing_rights__click")
-        ObservingRightsFragment.show(fragmentManager)
-    }
-
-    private fun onDartList() {
-        trueAnalytics.clickButton("${screenName()}__spac_dart_list__click")
-        DartListFragment.show(fragmentManager)
-    }
-
-    private fun onSpacSchedule() {
-        trueAnalytics.clickButton("${screenName()}__spac_schedule__click")
-        SpacScheduleFragment.show(fragmentManager)
-    }
-
-    private fun onVolumeRanking() {
-        trueAnalytics.clickButton("${screenName()}__volume_ranking__click")
-        VolumeRankingFragment.show(fragmentManager)
-    }
-
-    private fun onAdminMenu() {
-        MyAdminFragment.show(fragmentManager)
     }
 }
 

--- a/app/src/main/java/com/trueedu/project/ui/views/spac/SpacScreen.kt
+++ b/app/src/main/java/com/trueedu/project/ui/views/spac/SpacScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.material3.NavigationBarDefaults
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.ScaffoldDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -30,11 +31,16 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.platform.LocalContext
 import androidx.fragment.app.FragmentManager
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import com.trueedu.project.MainViewModel
 import com.trueedu.project.analytics.TrueAnalytics
 import com.trueedu.project.data.RemoteConfig
-import com.trueedu.project.data.spac.SpacManager
 import com.trueedu.project.model.dto.firebase.shouldShowRedemption
 import com.trueedu.project.ui.ads.AdmobManager
 import com.trueedu.project.ui.ads.NativeAdView
@@ -45,105 +51,39 @@ import com.trueedu.project.ui.common.TouchIcon24
 import com.trueedu.project.ui.common.TrueText
 import com.trueedu.project.ui.spac.SpacFilterBottomSheet
 import com.trueedu.project.ui.views.StockDetailFragment
-import com.trueedu.project.ui.views.home.BottomNavScreen
 import com.trueedu.project.ui.views.order.OrderFragment
 import com.trueedu.project.ui.views.search.SearchBar
 import com.trueedu.project.ui.views.setting.AppKeyInputFragment
 import com.trueedu.project.utils.formatter.safeDouble
 
-class SpacScreen(
-    private val mainVm: MainViewModel,
-    private val vm: SpacViewModel,
-    private val spacManager: SpacManager,
-    private val trueAnalytics: TrueAnalytics,
-    private val remoteConfig: RemoteConfig,
-    private val admobManager: AdmobManager,
-    private val fragmentManager: FragmentManager,
-): BottomNavScreen {
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+fun SpacScreen(
+    trueAnalytics: TrueAnalytics,
+    remoteConfig: RemoteConfig,
+    admobManager: AdmobManager,
+    fragmentManager: FragmentManager,
+    mainVm: MainViewModel = hiltViewModel(LocalContext.current as ComponentActivity),
+    vm: SpacViewModel = hiltViewModel(),
+) {
+    val lifecycleOwner = LocalLifecycleOwner.current
 
-    @OptIn(ExperimentalFoundationApi::class)
-    @Composable
-    override fun Draw() {
-        Scaffold(
-            topBar = {
-                SpacScreenTopBar(vm.sort.value, ::onSortOption, ::onSpacFilter)
-            },
-            bottomBar = {
-                if (remoteConfig.adVisible.value && admobManager.nativeAd.value != null) {
-                    NativeAdView(admobManager.nativeAd.value!!)
-                }
-            },
-            contentWindowInsets =
-                ScaffoldDefaults.contentWindowInsets.exclude(NavigationBarDefaults.windowInsets),
-            modifier = Modifier
-                .fillMaxSize()
-                .background(color = MaterialTheme.colorScheme.background),
-        ) { innerPadding ->
-            val loading by spacManager.loading.collectAsState()
-            if (loading) {
-                LoadingView()
-                return@Scaffold
+    DisposableEffect(lifecycleOwner) {
+        val observer = LifecycleEventObserver { _, event ->
+            when (event) {
+                Lifecycle.Event.ON_START -> vm.onStart()
+                Lifecycle.Event.ON_STOP -> vm.onStop()
+                else -> Unit
             }
-
-            val state = rememberLazyListState()
-
-            LaunchedEffect(key1 = loading) {
-                state.scrollToItem(1)
-            }
-
-            LazyColumn(
-                state = state,
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(innerPadding)
-            ) {
-                item { SearchBar(searchText = vm.searchInput) {} }
-                stickyHeader { SpacSectionView(vm::setSort) }
-
-                itemsIndexed(vm.stocks.value, key = { i, _ -> i }) { i, item ->
-
-                    val spacRefund = spacManager.spacRefundMap.value[item.code]
-                    val redemptionValue = spacManager.redemptionValueMap[item.code]
-                    val expectedProfit: Double?
-                    val expectedProfitRate: Double?
-                    if (spacRefund?.shouldShowRedemption() == true) {
-                        expectedProfit = redemptionValue?.first
-                        expectedProfitRate = redemptionValue?.second
-                    } else {
-                        expectedProfit = null
-                        expectedProfitRate = null
-                    }
-                    val userStock = mainVm.userStocks.value?.output1?.firstOrNull {
-                        it.code == item.code
-                    }
-
-                    // 한투 계좌 보유가 있으면 표시하고, 없으면 수동 보유를 표시함
-                    val holdingNum = userStock?.holdingQuantity.safeDouble().takeIf { it > 0 }
-                        ?: -vm.holdingNum(item.code)
-
-                    val hasDisclosure = vm.hasDisclosure(item.code)
-
-                    SpacItem(i, item,
-                        spacManager.priceMap[item.code] ?: 0.0,
-                        spacManager.priceChangeMap[item.code],
-                        spacManager.volumeMap[item.code] ?: 0L,
-                        expectedProfit,
-                        expectedProfitRate,
-                        holdingNum,
-                        hasDisclosure,
-                        ::onPriceClick
-                    ) {
-                        StockDetailFragment.show(item, fragmentManager)
-                    }
-                }
-            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose {
+            lifecycleOwner.lifecycle.removeObserver(observer)
         }
     }
 
-    // 정렬하기
-    private fun onSortOption() {
-        trueAnalytics.clickButton("${screenName()}__sort_option__click")
-
+    fun onSortOption() {
+        trueAnalytics.clickButton("spac__sort_option__click")
         val selected = SpacSort.entries.indexOfFirst { it == vm.sort.value }
         BottomSelectionFragment.show(
             selected = selected,
@@ -152,7 +92,7 @@ class SpacScreen(
             onSelected = {
                 val option = SpacSort.entries[it]
                 trueAnalytics.clickButton(
-                    "${screenName()}__sort__click",
+                    "spac__sort__click",
                     mapOf("sort_type" to option.title)
                 )
                 vm.setSort(option)
@@ -161,9 +101,8 @@ class SpacScreen(
         )
     }
 
-    // 스팩 필터 도구
-    private fun onSpacFilter() {
-        trueAnalytics.clickButton("${screenName()}__filter__click")
+    fun onSpacFilter() {
+        trueAnalytics.clickButton("spac__filter__click")
         SpacFilterBottomSheet.show(vm.spacFilter, fragmentManager) {
             if (vm.spacFilter != it) {
                 vm.spacFilter = it
@@ -172,23 +111,85 @@ class SpacScreen(
         }
     }
 
-    private fun onPriceClick(code: String) {
-        trueAnalytics.clickButton("${screenName()}__price__click")
-        if (vm.hasAppKey()) {
-            OrderFragment.show(code, fragmentManager)
-        } else {
-            AppKeyInputFragment.show(false, fragmentManager)
+    Scaffold(
+        topBar = {
+            SpacScreenTopBar(vm.sort.value, ::onSortOption, ::onSpacFilter)
+        },
+        bottomBar = {
+            if (remoteConfig.adVisible.value && admobManager.nativeAd.value != null) {
+                NativeAdView(admobManager.nativeAd.value!!)
+            }
+        },
+        contentWindowInsets =
+            ScaffoldDefaults.contentWindowInsets.exclude(NavigationBarDefaults.windowInsets),
+        modifier = Modifier
+            .fillMaxSize()
+            .background(color = MaterialTheme.colorScheme.background),
+    ) { innerPadding ->
+        val loading by vm.spacManager.loading.collectAsState()
+        if (loading) {
+            LoadingView()
+            return@Scaffold
         }
-    }
 
-    override fun onStart() {
-        super.onStart()
-        spacManager.onStart()
-    }
+        val state = rememberLazyListState()
 
-    override fun onStop() {
-        super.onStop()
-        spacManager.onStop()
+        LaunchedEffect(key1 = loading) {
+            state.scrollToItem(1)
+        }
+
+        LazyColumn(
+            state = state,
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding)
+        ) {
+            item { SearchBar(searchText = vm.searchInput) {} }
+            stickyHeader { SpacSectionView(vm::setSort) }
+
+            itemsIndexed(vm.stocks.value, key = { i, _ -> i }) { i, item ->
+
+                val spacRefund = vm.spacManager.spacRefundMap.value[item.code]
+                val redemptionValue = vm.spacManager.redemptionValueMap[item.code]
+                val expectedProfit: Double?
+                val expectedProfitRate: Double?
+                if (spacRefund?.shouldShowRedemption() == true) {
+                    expectedProfit = redemptionValue?.first
+                    expectedProfitRate = redemptionValue?.second
+                } else {
+                    expectedProfit = null
+                    expectedProfitRate = null
+                }
+                val userStock = mainVm.userStocks.value?.output1?.firstOrNull {
+                    it.code == item.code
+                }
+
+                val holdingNum = userStock?.holdingQuantity.safeDouble().takeIf { it > 0 }
+                    ?: -vm.holdingNum(item.code)
+
+                val hasDisclosure = vm.hasDisclosure(item.code)
+
+                SpacItem(i, item,
+                    vm.spacManager.priceMap[item.code] ?: 0.0,
+                    vm.spacManager.priceChangeMap[item.code],
+                    vm.spacManager.volumeMap[item.code] ?: 0L,
+                    expectedProfit,
+                    expectedProfitRate,
+                    holdingNum,
+                    hasDisclosure,
+                    onPriceClick = { code ->
+                        trueAnalytics.clickButton("spac__price__click")
+                        if (vm.hasAppKey()) {
+                            OrderFragment.show(code, fragmentManager)
+                        } else {
+                            AppKeyInputFragment.show(false, fragmentManager)
+                        }
+                    }
+                ) {
+                    StockDetailFragment.show(item, fragmentManager)
+                }
+            }
+        }
     }
 }
 

--- a/app/src/main/java/com/trueedu/project/ui/views/spac/SpacViewModel.kt
+++ b/app/src/main/java/com/trueedu/project/ui/views/spac/SpacViewModel.kt
@@ -28,7 +28,7 @@ class SpacViewModel @Inject constructor(
     private val manualAssets: ManualAssets,
     private val stockPool: StockPool,
     private val tokenKeyManager: TokenKeyManager,
-    private val spacManager: SpacManager,
+    val spacManager: SpacManager,
     private val dartManager: DartManager,
     private val watchList: WatchList,
 ): ViewModel() {
@@ -122,6 +122,14 @@ class SpacViewModel @Inject constructor(
 
     fun hasDisclosure(code: String): Boolean {
         return dartManager.hasDisclosure(code)
+    }
+
+    fun onStart() {
+        spacManager.onStart()
+    }
+
+    fun onStop() {
+        spacManager.onStop()
     }
 
     private fun growthRate(stock: StockInfo): Double {

--- a/app/src/main/java/com/trueedu/project/ui/views/watch/WatchScreen.kt
+++ b/app/src/main/java/com/trueedu/project/ui/views/watch/WatchScreen.kt
@@ -1,6 +1,5 @@
 package com.trueedu.project.ui.views.watch
 
-import android.app.Activity
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -19,7 +18,6 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.pager.HorizontalPager
-import androidx.compose.foundation.pager.PagerState
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
@@ -30,6 +28,7 @@ import androidx.compose.material3.NavigationBarDefaults
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.ScaffoldDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -44,9 +43,14 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import androidx.fragment.app.FragmentManager
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import com.trueedu.project.analytics.TrueAnalytics
 import com.trueedu.project.data.RemoteConfig
 import com.trueedu.project.data.StockPool
@@ -65,7 +69,6 @@ import com.trueedu.project.ui.views.StockDetailFragment
 import com.trueedu.project.ui.views.common.DesignatedBadge
 import com.trueedu.project.ui.views.common.DisclosurePoint
 import com.trueedu.project.ui.views.common.HaltBadge
-import com.trueedu.project.ui.views.home.BottomNavScreen
 import com.trueedu.project.ui.views.order.OrderFragment
 import com.trueedu.project.ui.views.search.StockSearchFragment
 import com.trueedu.project.ui.views.setting.AppKeyInputFragment
@@ -74,246 +77,250 @@ import com.trueedu.project.utils.formatter.RateFormatter
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.mapNotNull
 
-class WatchScreen(
-    private val activity: Activity,
-    private val vm: WatchListViewModel,
-    private val admobManager: AdmobManager,
-    private val remoteConfig: RemoteConfig,
-    private val trueAnalytics: TrueAnalytics,
-    private val fragmentManager: FragmentManager,
-): BottomNavScreen {
-    private var pagerState: PagerState? = null
+@Composable
+fun WatchScreen(
+    admobManager: AdmobManager,
+    remoteConfig: RemoteConfig,
+    trueAnalytics: TrueAnalytics,
+    fragmentManager: FragmentManager,
+    vm: WatchListViewModel = hiltViewModel(),
+) {
+    val context = LocalContext.current
+    val lifecycleOwner = LocalLifecycleOwner.current
 
-    @Composable
-    override fun Draw() {
-        LaunchedEffect(pagerState) {
-            snapshotFlow { pagerState?.currentPage }
-                .mapNotNull { it?.mod(vm.pageCount()) }
-                .collectLatest {
-                    vm.currentPage.value = it
-                }
+    DisposableEffect(lifecycleOwner) {
+        val observer = LifecycleEventObserver { _, event ->
+            when (event) {
+                Lifecycle.Event.ON_START -> vm.init()
+                Lifecycle.Event.ON_STOP -> vm.onStop()
+                else -> Unit
+            }
         }
-        Scaffold(
-            topBar = {
-                BackTitleTopBar(
-                    title = vm.groupName(vm.currentPage.value),
-                    onBack = null,
-                    actionIcon = Icons.Filled.Search,
-                    onAction = ::onSearch,
-                    actionIcon2 = Icons.Filled.Edit,
-                    onAction2 = ::onEdit,
-                )
-            },
-            bottomBar = {
-                if (
-                    !vm.loading.value &&
-                    vm.currentPage.value != null &&
-                    vm.getItems(vm.currentPage.value!!).isNotEmpty() &&
-                    remoteConfig.adVisible.value &&
-                    admobManager.nativeAd.value != null
-                ) {
-                    Box(modifier = Modifier.fillMaxWidth()) {
-                        NativeAdView(admobManager.nativeAd.value!!)
-                    }
-                }
-            },
-            contentWindowInsets =
-                ScaffoldDefaults.contentWindowInsets.exclude(NavigationBarDefaults.windowInsets),
-            modifier = Modifier.fillMaxSize()
-        ) { innerPadding ->
-
-            if (pagerState == null) {
-                pagerState = rememberPagerState(
-                    initialPage = 100 * vm.pageCount(),
-                    initialPageOffsetFraction = 0f,
-                    pageCount = { 200 * vm.pageCount() }, // infinite loop
-                )
-            }
-
-            val status by vm.stockPool.status.collectAsState()
-            // 주식 정보와 관심 종목 정보를 모두 받아야 데이터 표시 가능
-            if (vm.loading.value || status != StockPool.Status.SUCCESS) {
-                LoadingView()
-                return@Scaffold
-            }
-
-            HorizontalPager(
-                state = pagerState!!,
-                modifier = Modifier.fillMaxSize()
-            ) { position ->
-                var selectedStock by remember { mutableStateOf<StockInfo?>(null) }
-                var selectedStockIndex by remember { mutableIntStateOf(-1) }
-                val state = rememberLazyListState()
-                LazyColumn(
-                    state = state,
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .padding(innerPadding)
-                ) {
-                    val items = vm.getItems(position % vm.pageCount())
-                    itemsIndexed(items, key = { _, item -> item }) { index, code ->
-                        val stock = vm.getStock(code) ?: return@itemsIndexed
-                        val tradeData = vm.priceManager.dataMap[code]
-                        val basePrice = vm.basePrices[code]?.output
-
-                        // appkey 가 없으면 그냥 전일 가격을 표시함
-                        val price = tradeData?.price ?: basePrice?.price?.toDouble() ?: vm.prevPrice(code)
-                        val delta = tradeData?.delta ?: basePrice?.priceChange?.toDouble()
-                        val rate = tradeData?.rate ?: basePrice?.priceChangeRate?.toDouble()
-                        val volume = tradeData?.volume ?: basePrice?.volume?.toDouble() ?: 0.0
-
-                        WatchingStockItem(
-                            nameKr = stock.nameKr,
-                            code = code,
-                            price = price,
-                            prevClose = tradeData?.previousClose ?: basePrice?.previousClosePrice?.toDouble(),
-                            open = tradeData?.open ?: basePrice?.open?.toDouble(),
-                            high = tradeData?.high ?: basePrice?.high?.toDouble(),
-                            low = tradeData?.low ?: basePrice?.low?.toDouble(),
-                            delta = delta,
-                            rate = rate,
-                            volume = volume,
-                            halt = stock.halt(),
-                            designated = stock.designated(),
-                            hasDisclosure = vm.hasDisclosure(code),
-                            onTradingClick = { gotoTrading(stock) },
-                            onClick = { gotoStockDetail(stock) },
-                        ) {
-                            logD("long click: ${stock.nameKr}")
-                            selectedStock = stock
-                            selectedStockIndex = index
-                        }
-                    }
-                } // end of LazyColumn
-
-                if (selectedStock != null) {
-                    Dialog(
-                        onDismissRequest = { selectedStock = null },
-                        properties = DialogProperties(usePlatformDefaultWidth = false) // Important for custom positioning
-                    ) {
-                        PopupBody(selectedStock!!, position, selectedStockIndex,
-                            moveTo = { index, toPage ->
-                                selectedStock = null
-                                vm.moveTo(index, toPage)
-                            },
-                            onRemove = {
-                                selectedStock = null
-                                vm.removeStock(selectedStockIndex)
-                            },
-                        )
-                    }
-                }
-            }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose {
+            lifecycleOwner.lifecycle.removeObserver(observer)
         }
     }
 
-    override fun onStart() {
-        vm.init()
+    val pagerState = rememberPagerState(
+        initialPage = 100 * vm.pageCount(),
+        initialPageOffsetFraction = 0f,
+        pageCount = { 200 * vm.pageCount() }, // infinite loop
+    )
+
+    LaunchedEffect(pagerState) {
+        snapshotFlow { pagerState.currentPage }
+            .mapNotNull { it.mod(vm.pageCount()) }
+            .collectLatest {
+                vm.currentPage.value = it
+            }
     }
 
-    override fun onStop() {
-        vm.onStop()
-    }
-
-    private fun doAfterLogin(action: () -> Unit) {
+    fun doAfterLogin(action: () -> Unit) {
         if (vm.googleAccount.loggedIn()) {
             action()
         } else {
-            vm.googleAccount.login(activity, action)
-        }
-    }
-
-    private fun onSearch() {
-        trueAnalytics.clickButton("watch_list__search__click")
-        doAfterLogin {
-            StockSearchFragment.show(vm.currentPage.value, fragmentManager)
-        }
-    }
-
-    private fun onEdit() {
-        trueAnalytics.clickButton("watch_list__edit__click")
-        doAfterLogin {
-            if (!vm.loading.value || vm.currentPage.value != null) {
-                WatchEditFragment.show(vm.currentPage.value!!, fragmentManager)
+            val activity = context as? android.app.Activity
+            if (activity != null) {
+                vm.googleAccount.login(activity, action)
+            } else {
+                action()
             }
         }
     }
 
-    private fun gotoTrading(stockInfo: StockInfo) {
-        if (vm.hasAppKey()) {
-            OrderFragment.show(stockInfo.code, fragmentManager)
-        } else {
-            AppKeyInputFragment.show(false, fragmentManager)
-        }
-    }
-
-    private fun gotoStockDetail(stockInfo: StockInfo) {
-        StockDetailFragment.show(stockInfo, fragmentManager)
-    }
-
-    @Composable
-    fun PopupBody(
-        item: StockInfo,
-        page: Int,
-        index: Int,
-        moveTo: (Int, Int) -> Unit,
-        onRemove: () -> Unit,
-    ) {
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(24.dp)
-                .background(
-                    MaterialTheme.colorScheme.background,
-                    shape = RoundedCornerShape(8.dp)
-                )
-                .padding(16.dp)
-        ) {
-            TrueText(
-                s = "${item.nameKr} 이동",
-                color = MaterialTheme.colorScheme.primary,
-                fontSize = 18,
-                fontWeight = FontWeight.Bold,
-                maxLines = 2,
+    Scaffold(
+        topBar = {
+            BackTitleTopBar(
+                title = vm.groupName(vm.currentPage.value),
+                onBack = null,
+                actionIcon = Icons.Filled.Search,
+                onAction = {
+                    trueAnalytics.clickButton("watch_list__search__click")
+                    doAfterLogin {
+                        StockSearchFragment.show(vm.currentPage.value, fragmentManager)
+                    }
+                },
+                actionIcon2 = Icons.Filled.Edit,
+                onAction2 = {
+                    trueAnalytics.clickButton("watch_list__edit__click")
+                    doAfterLogin {
+                        if (!vm.loading.value || vm.currentPage.value != null) {
+                            WatchEditFragment.show(vm.currentPage.value!!, fragmentManager)
+                        }
+                    }
+                },
             )
-            Margin(8)
-            DividerHorizontal()
-            Column(modifier = Modifier.fillMaxWidth()) {
-                repeat(vm.pageCount()) {
-                    TrueText(
-                        s = vm.groupName(it),
-                        fontSize = 16,
-                        color = MaterialTheme.colorScheme.primary
-                            .copy(alpha = if (it == page) 0.1f else 1f),
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .clickable {
-                                if (it != page) {
-                                    moveTo(index, it)
-                                }
-                            }
-                            .padding(vertical = 8.dp),
-                    )
-                    DividerHorizontal()
+        },
+        bottomBar = {
+            if (
+                !vm.loading.value &&
+                vm.currentPage.value != null &&
+                vm.getItems(vm.currentPage.value!!).isNotEmpty() &&
+                remoteConfig.adVisible.value &&
+                admobManager.nativeAd.value != null
+            ) {
+                Box(modifier = Modifier.fillMaxWidth()) {
+                    NativeAdView(admobManager.nativeAd.value!!)
                 }
             }
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .clickable { onRemove() }
-                    .padding(top = 8.dp),
-                horizontalArrangement = Arrangement.End,
-            ) {
-                TrueText(
-                    s = "관심종목에서 삭제",
-                    color = MaterialTheme.colorScheme.primary,
-                    fontSize = 16,
-                    style = TextStyle(textDecoration = TextDecoration.Underline),
-                    modifier = Modifier.padding(vertical = 8.dp),
-                )
-            }
-            Margin(8)
+        },
+        contentWindowInsets =
+            ScaffoldDefaults.contentWindowInsets.exclude(NavigationBarDefaults.windowInsets),
+        modifier = Modifier.fillMaxSize()
+    ) { innerPadding ->
+
+        val status by vm.stockPool.status.collectAsState()
+        // 주식 정보와 관심 종목 정보를 모두 받아야 데이터 표시 가능
+        if (vm.loading.value || status != StockPool.Status.SUCCESS) {
+            LoadingView()
+            return@Scaffold
         }
+
+        HorizontalPager(
+            state = pagerState,
+            modifier = Modifier.fillMaxSize()
+        ) { position ->
+            var selectedStock by remember { mutableStateOf<StockInfo?>(null) }
+            var selectedStockIndex by remember { mutableIntStateOf(-1) }
+            val state = rememberLazyListState()
+            LazyColumn(
+                state = state,
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(innerPadding)
+            ) {
+                val items = vm.getItems(position % vm.pageCount())
+                itemsIndexed(items, key = { _, item -> item }) { index, code ->
+                    val stock = vm.getStock(code) ?: return@itemsIndexed
+                    val tradeData = vm.priceManager.dataMap[code]
+                    val basePrice = vm.basePrices[code]?.output
+
+                    val price = tradeData?.price ?: basePrice?.price?.toDouble() ?: vm.prevPrice(code)
+                    val delta = tradeData?.delta ?: basePrice?.priceChange?.toDouble()
+                    val rate = tradeData?.rate ?: basePrice?.priceChangeRate?.toDouble()
+                    val volume = tradeData?.volume ?: basePrice?.volume?.toDouble() ?: 0.0
+
+                    WatchingStockItem(
+                        nameKr = stock.nameKr,
+                        code = code,
+                        price = price,
+                        prevClose = tradeData?.previousClose ?: basePrice?.previousClosePrice?.toDouble(),
+                        open = tradeData?.open ?: basePrice?.open?.toDouble(),
+                        high = tradeData?.high ?: basePrice?.high?.toDouble(),
+                        low = tradeData?.low ?: basePrice?.low?.toDouble(),
+                        delta = delta,
+                        rate = rate,
+                        volume = volume,
+                        halt = stock.halt(),
+                        designated = stock.designated(),
+                        hasDisclosure = vm.hasDisclosure(code),
+                        onTradingClick = {
+                            if (vm.hasAppKey()) {
+                                OrderFragment.show(stock.code, fragmentManager)
+                            } else {
+                                AppKeyInputFragment.show(false, fragmentManager)
+                            }
+                        },
+                        onClick = {
+                            StockDetailFragment.show(stock, fragmentManager)
+                        },
+                    ) {
+                        logD("long click: ${stock.nameKr}")
+                        selectedStock = stock
+                        selectedStockIndex = index
+                    }
+                }
+            } // end of LazyColumn
+
+            if (selectedStock != null) {
+                Dialog(
+                    onDismissRequest = { selectedStock = null },
+                    properties = DialogProperties(usePlatformDefaultWidth = false)
+                ) {
+                    PopupBody(
+                        vm = vm,
+                        item = selectedStock!!,
+                        page = position,
+                        index = selectedStockIndex,
+                        moveTo = { index, toPage ->
+                            selectedStock = null
+                            vm.moveTo(index, toPage)
+                        },
+                        onRemove = {
+                            selectedStock = null
+                            vm.removeStock(selectedStockIndex)
+                        },
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun PopupBody(
+    vm: WatchListViewModel,
+    item: StockInfo,
+    page: Int,
+    index: Int,
+    moveTo: (Int, Int) -> Unit,
+    onRemove: () -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(24.dp)
+            .background(
+                MaterialTheme.colorScheme.background,
+                shape = RoundedCornerShape(8.dp)
+            )
+            .padding(16.dp)
+    ) {
+        TrueText(
+            s = "${item.nameKr} 이동",
+            color = MaterialTheme.colorScheme.primary,
+            fontSize = 18,
+            fontWeight = FontWeight.Bold,
+            maxLines = 2,
+        )
+        Margin(8)
+        DividerHorizontal()
+        Column(modifier = Modifier.fillMaxWidth()) {
+            repeat(vm.pageCount()) {
+                TrueText(
+                    s = vm.groupName(it),
+                    fontSize = 16,
+                    color = MaterialTheme.colorScheme.primary
+                        .copy(alpha = if (it == page) 0.1f else 1f),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clickable {
+                            if (it != page) {
+                                moveTo(index, it)
+                            }
+                        }
+                        .padding(vertical = 8.dp),
+                )
+                DividerHorizontal()
+            }
+        }
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clickable { onRemove() }
+                .padding(top = 8.dp),
+            horizontalArrangement = Arrangement.End,
+        ) {
+            TrueText(
+                s = "관심종목에서 삭제",
+                color = MaterialTheme.colorScheme.primary,
+                fontSize = 16,
+                style = TextStyle(textDecoration = TextDecoration.Underline),
+                modifier = Modifier.padding(vertical = 8.dp),
+            )
+        }
+        Margin(8)
     }
 }
 
@@ -383,7 +390,6 @@ private fun WatchingStockItem(
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.SpaceBetween,
         ) {
-            // ohlc 데이터가 있으면 캔들 표시
             if (prevClose != null && open != null && high != null && low != null) {
                 DrawCandle(
                     prevClose = prevClose,
@@ -393,7 +399,6 @@ private fun WatchingStockItem(
                     close = price,
                 )
             } else {
-                // 정렬을 위해
                 Margin(1)
             }
 


### PR DESCRIPTION
## 변경 내용

MainActivity에서 Screen 인스턴스를 생성해 NavHost로 전달하던 방식을 → NavHost `composable` 블록 내에서 top-level Composable 함수를 직접 호출하는 방식으로 리팩토링

### 주요 변경사항

- **HomeScreen / WatchScreen / SpacScreen / MenuScreen** — 클래스 → top-level `@Composable` 함수 전환
- **ViewModel** — MainActivity의 `viewModels<>()` 제거, 각 Screen 내부에서 `hiltViewModel()`로 직접 주입
- **MainActivity** — Screen 인스턴스 4개 및 `watchVm`, `spacVm`, `homeDrawerVm` 제거, `screenOf()` 함수 제거
- **MainNavigation** — Screen 인스턴스 파라미터 제거, composable 블록에서 직접 호출
- **MainScreen** — `screenOf()` / `BottomNavScreen` lifecycle observer 제거, `homeDrawerVm` 내부 `hiltViewModel()`로 이동
- **SpacViewModel** — `spacManager` public으로 변경, `onStart()`/`onStop()` 위임 메서드 추가
- **Lifecycle** — onStart/onStop을 각 Screen 내 `DisposableEffect`로 처리
- `activity: Activity` 파라미터 → `LocalContext.current`로 대체