### PR TITLE
MainActivity: PopupFragment 대신 composable TrueDialog 사용

### DIFF
--- a/app/src/main/java/com/trueedu/project/MainActivity.kt
+++ b/app/src/main/java/com/trueedu/project/MainActivity.kt
@@ -33,8 +33,8 @@ import com.trueedu.project.repository.local.Local
 import com.trueedu.project.repository.remote.AuthRemote
 import com.trueedu.project.ui.ads.AdmobManager
 import com.trueedu.project.ui.common.ButtonAction
-import com.trueedu.project.ui.common.PopupFragment
 import com.trueedu.project.ui.common.PopupType
+import com.trueedu.project.ui.common.TrueDialog
 import com.trueedu.project.ui.main.MainNavigation
 import com.trueedu.project.ui.main.MainScreen
 import com.trueedu.project.ui.theme.TrueProjectTheme
@@ -86,23 +86,7 @@ class MainActivity : AppCompatActivity() {
         if (screen.keepScreenOn.value) {
             keepScreenOnOff(true)
         }
-
-        if (local.disclaimerVisible) {
-            PopupFragment.show(
-                title = "투자 유의 사항",
-                desc = """
-                    본 앱에서 제공하는 정보는 투자 참고용으로만 사용되며, 투자 권유 또는 자문을 목적으로 하지 않습니다. 투자 결정은 사용자 본인의 판단에 따라 신중하게 이루어져야 하며, 투자 결과에 대한 책임은 사용자 본인에게 있습니다.
-
-                    The information provided in this app is for informational purposes only and is not intended as investment advice or a recommendation to buy or sell any securities. Investment decisions should be made based on your own judgment and research. You are solely responsible for your investment results.
-                """.trimIndent(),
-                popupType = PopupType.OK,
-                buttonActions = listOf(
-                    ButtonAction("확인") { local.disclaimerVisible = false }
-                ),
-                cancellable = true,
-                fragmentManager = supportFragmentManager,
-            )
-        }
+        // disclaimer는 setContent 내 composable로 표시
     }
 
     private fun keepScreenOnOff(on: Boolean) {
@@ -163,17 +147,42 @@ class MainActivity : AppCompatActivity() {
             ) {
                 if (vm.forceUpdateVisible.value) {
                     ForceUpdateView(::gotoPlayStore)
-                } else if (vm.appNotice.value.available() && local.appNoticeId < vm.appNotice.value.id) {
-                    AppNoticePopup(vm.appNotice.value, supportFragmentManager) {
-                        trueAnalytics.clickButton("main__notice_close__click")
-                        if (vm.appNotice.value.cancellable) {
-                            local.appNoticeId = vm.appNotice.value.id
-                            vm.appNotice.value = AppNotice()
-                        } else {
-                            finishAffinity()
+                } else {
+                    // disclaimer 팝업 (최초 1회)
+                    if (vm.disclaimerVisible.value) {
+                        fun dismissDisclaimer() {
+                            local.disclaimerVisible = false
+                            vm.disclaimerVisible.value = false
+                        }
+                        TrueDialog(
+                            title = "투자 유의 사항",
+                            desc = """
+                                본 앱에서 제공하는 정보는 투자 참고용으로만 사용되며, 투자 권유 또는 자문을 목적으로 하지 않습니다. 투자 결정은 사용자 본인의 판단에 따라 신중하게 이루어져야 하며, 투자 결과에 대한 책임은 사용자 본인에게 있습니다.
+
+                                The information provided in this app is for informational purposes only and is not intended as investment advice or a recommendation to buy or sell any securities. Investment decisions should be made based on your own judgment and research. You are solely responsible for your investment results.
+                            """.trimIndent(),
+                            popupType = PopupType.OK,
+                            actions = listOf(
+                                ButtonAction("확인") { dismissDisclaimer() }
+                            ),
+                            cancellable = true,
+                            onDismiss = { dismissDisclaimer() },
+                        )
+                    }
+
+                    // 앱 공지 팝업
+                    if (vm.appNotice.value.available() && local.appNoticeId < vm.appNotice.value.id) {
+                        AppNoticePopup(vm.appNotice.value) {
+                            trueAnalytics.clickButton("main__notice_close__click")
+                            if (vm.appNotice.value.cancellable) {
+                                local.appNoticeId = vm.appNotice.value.id
+                                vm.appNotice.value = AppNotice()
+                            } else {
+                                finishAffinity()
+                            }
                         }
                     }
-                } else {
+
                     MainScreen(
                         activity = this,
                         googleAccount = googleAccount,

--- a/app/src/main/java/com/trueedu/project/MainViewModel.kt
+++ b/app/src/main/java/com/trueedu/project/MainViewModel.kt
@@ -42,6 +42,9 @@ class MainViewModel @Inject constructor(
     // notice
     val appNotice = mutableStateOf(AppNotice())
 
+    // disclaimer
+    val disclaimerVisible = mutableStateOf(local.disclaimerVisible)
+
     fun init() {
         if (local.getUserKeys().isEmpty()) {
             // 키가 없어서 자산을 못 불러오면 로딩 상태가 불필요함

--- a/app/src/main/java/com/trueedu/project/ui/common/TrueDialog.kt
+++ b/app/src/main/java/com/trueedu/project/ui/common/TrueDialog.kt
@@ -1,0 +1,166 @@
+package com.trueedu.project.ui.common
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonColors
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+
+/**
+ * PopupFragment 를 대체하는 순수 Composable Dialog.
+ *
+ * @param popupType   버튼 색상 타입
+ * @param title       다이얼로그 제목
+ * @param desc        본문 텍스트
+ * @param actions     버튼 목록. ButtonAction.onClick 은 버튼 고유 동작만 담당하며,
+ *                    다이얼로그 닫기는 TrueDialog 가 별도로 처리합니다.
+ * @param cancellable 바깥 터치 / 뒤로가기로 닫기 허용 여부
+ * @param onDismiss   다이얼로그가 닫힐 때 호출 (버튼 클릭 및 외부 취소 모두 포함)
+ */
+@Composable
+fun TrueDialog(
+    popupType: PopupType = PopupType.OK,
+    title: String,
+    desc: String,
+    actions: List<ButtonAction> = emptyList(),
+    cancellable: Boolean = true,
+    onDismiss: () -> Unit = {},
+) {
+    var visible by remember { mutableStateOf(true) }
+
+    fun dismiss() {
+        visible = false
+        onDismiss()
+    }
+
+    if (!visible) return
+
+    Dialog(
+        onDismissRequest = { if (cancellable) dismiss() },
+        properties = DialogProperties(
+            dismissOnBackPress = cancellable,
+            dismissOnClickOutside = cancellable,
+        ),
+    ) {
+        TrueDialogBody(
+            popupType = popupType,
+            title = title,
+            desc = desc,
+            actions = actions,
+            dismissPopup = ::dismiss,
+        )
+    }
+}
+
+@Preview
+@Composable
+internal fun TrueDialogBody(
+    popupType: PopupType = PopupType.OK,
+    title: String = "test",
+    desc: String = "test\nDESC",
+    actions: List<ButtonAction> = listOf(
+        ButtonAction("ok", {}),
+        ButtonAction("cancel", {}),
+    ),
+    dismissPopup: () -> Unit = {},
+) {
+    RoundedColumn(
+        radius = 20,
+        bgColor = MaterialTheme.colorScheme.background,
+        modifier = Modifier
+            .width(300.dp)
+            .wrapContentHeight()
+    ) {
+        TrueText(
+            s = title,
+            color = MaterialTheme.colorScheme.primary,
+            fontSize = 20,
+            fontWeight = FontWeight.W600,
+            textAlign = TextAlign.Center,
+            modifier = Modifier
+                .padding(top = 32.dp, start = 20.dp, end = 20.dp)
+                .wrapContentHeight()
+                .fillMaxWidth()
+        )
+
+        val scrollState = rememberScrollState()
+        val screenHeightDp = LocalConfiguration.current.screenHeightDp
+        val maxBodyHeight = (screenHeightDp * 0.5f).dp
+
+        Box(
+            modifier = Modifier
+                .padding(top = 8.dp, start = 16.dp, end = 16.dp)
+                .heightIn(max = maxBodyHeight)
+                .verticalScroll(scrollState)
+                .fillMaxWidth()
+                .wrapContentHeight()
+        ) {
+            TrueText(
+                s = desc,
+                color = MaterialTheme.colorScheme.secondary,
+                fontSize = 14,
+                textAlign = TextAlign.Center,
+                maxLines = Int.MAX_VALUE,
+                modifier = Modifier.fillMaxWidth()
+            )
+        }
+
+        Row(
+            modifier = Modifier
+                .padding(16.dp)
+                .wrapContentSize()
+        ) {
+            val colorScheme = MaterialTheme.colorScheme
+
+            actions.reversed().forEachIndexed { i, (label, onClick) ->
+                val (textColor, bgColor) = if (i == actions.lastIndex) {
+                    popupType.mainColor(colorScheme)
+                } else {
+                    popupType.cancelColor(colorScheme)
+                }
+
+                Button(
+                    onClick = {
+                        onClick?.invoke()
+                        dismissPopup()
+                    },
+                    modifier = Modifier
+                        .weight(1f)
+                        .height(48.dp)
+                        .padding(horizontal = 8.dp),
+                    colors = ButtonColors(
+                        containerColor = bgColor,
+                        contentColor = textColor,
+                        disabledContainerColor = Color.Transparent,
+                        disabledContentColor = Color.Transparent,
+                    ),
+                ) {
+                    TrueText(s = label, fontSize = 14, color = textColor)
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/trueedu/project/ui/views/home/AppNoticePopup.kt
+++ b/app/src/main/java/com/trueedu/project/ui/views/home/AppNoticePopup.kt
@@ -2,47 +2,37 @@ package com.trueedu.project.ui.views.home
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.fragment.app.FragmentManager
 import com.trueedu.project.model.dto.firebase.AppNotice
 import com.trueedu.project.ui.common.ButtonAction
-import com.trueedu.project.ui.common.PopupFragment
 import com.trueedu.project.ui.common.PopupType
-
+import com.trueedu.project.ui.common.TrueDialog
 
 @Composable
 fun AppNoticePopup(
     appNotice: AppNotice,
-    fm: FragmentManager,
     onClickButton: (() -> Unit) = {},
 ) {
-    AppNoticePopupInternal(
-        appNotice.title,
-        appNotice.body,
+    TrueDialog(
+        title = appNotice.title,
+        desc = appNotice.body,
+        popupType = PopupType.OK,
+        actions = listOf(
+            ButtonAction("확인") { onClickButton() }
+        ),
         cancellable = appNotice.cancellable,
-        fm = fm,
-        onClickButton = onClickButton,
+        onDismiss = {},
     )
 }
 
 @Preview(showBackground = true)
 @Composable
-private fun AppNoticePopupInternal(
-    title: String = "Title",
-    body: String = "공지 내용입니다",
-    cancellable: Boolean = true,
-    fm: FragmentManager? = null,
-    onClickButton: (() -> Unit) = {},
-) {
-    PopupFragment.show(
-        title = title,
-        desc = body,
-        popupType = PopupType.OK,
-        buttonActions = listOf(
-            ButtonAction("확인") {
-                onClickButton()
-            }
-        ),
-        cancellable = cancellable,
-        fragmentManager = fm!!,
+private fun AppNoticePopupPreview() {
+    AppNoticePopup(
+        appNotice = AppNotice(
+            id = 1,
+            title = "공지사항",
+            body = "공지 내용입니다",
+            cancellable = true,
+        )
     )
 }


### PR DESCRIPTION
## 변경 사항

### 신규
- `TrueDialog.kt`: `Dialog { }` composable로 감싼 순수 Compose 팝업 컴포넌트 (기존 `PopupFragment`의 `PopupBody` 로직 이전)

### 수정
- `AppNoticePopup.kt`: `PopupFragment.show()` + `FragmentManager` 의존성 제거 → `TrueDialog` 사용
- `MainViewModel`: `disclaimerVisible` MutableState 추가 (composable 재구성 트리거)
- `MainActivity`
  - `onStart()`: `PopupFragment` 호출 제거
  - `setContent`: disclaimer · 앱 공지 팝업을 composable 트리 안에서 조건부 렌더링

## 참고
`PopupFragment`는 `SettingFragment`, `EditAssetFragment` 등에서 아직 사용 중이므로 삭제하지 않음