### PR TITLE
홈 화면 로딩 스켈레톤 UI 구현

### DIFF
--- a/app/src/main/java/com/trueedu/project/ui/views/home/HomeScreen.kt
+++ b/app/src/main/java/com/trueedu/project/ui/views/home/HomeScreen.kt
@@ -1,22 +1,29 @@
 package com.trueedu.project.ui.views.home
 
 import android.widget.Toast
+import androidx.activity.ComponentActivity
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.exclude
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.NavigationBarDefaults
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.ScaffoldDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
-import androidx.activity.ComponentActivity
 import androidx.fragment.app.FragmentManager
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
@@ -26,10 +33,8 @@ import com.trueedu.project.MainViewModel
 import com.trueedu.project.analytics.TrueAnalytics
 import com.trueedu.project.data.RemoteConfig
 import com.trueedu.project.data.StockPool
-import com.trueedu.project.model.dto.firebase.StockInfo
 import com.trueedu.project.ui.ads.AdmobManager
 import com.trueedu.project.ui.ads.NativeAdView
-import com.trueedu.project.ui.common.LoadingView
 import com.trueedu.project.ui.common.Margin
 import com.trueedu.project.ui.topbar.MainTopBar
 import com.trueedu.project.ui.views.StockDetailFragment
@@ -86,8 +91,9 @@ fun HomeScreen(
         modifier = Modifier.fillMaxSize()
     ) { innerPadding ->
 
-        if (vm.loading.value) {
-            LoadingView()
+        // 초기 로딩 (데이터 없음): 스켈레톤 표시
+        if (vm.loading.value && vm.userStocks.value == null) {
+            HomeLoadingSkeleton(modifier = Modifier.padding(innerPadding))
             return@Scaffold
         }
 
@@ -99,6 +105,23 @@ fun HomeScreen(
                 .fillMaxSize()
                 .padding(innerPadding)
         ) {
+            // 새로고침 중 (기존 데이터 있음): 상단 작은 인디케이터
+            if (vm.loading.value) {
+                item {
+                    Box(
+                        contentAlignment = Alignment.Center,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(40.dp)
+                    ) {
+                        CircularProgressIndicator(
+                            color = MaterialTheme.colorScheme.tertiary,
+                            modifier = Modifier.size(24.dp)
+                        )
+                    }
+                }
+            }
+
             vm.userStocks.value?.output2?.firstOrNull()?.let {
                 item {
                     AccountInfo(

--- a/app/src/main/java/com/trueedu/project/ui/views/home/HomeSkeleton.kt
+++ b/app/src/main/java/com/trueedu/project/ui/views/home/HomeSkeleton.kt
@@ -1,0 +1,162 @@
+package com.trueedu.project.ui.views.home
+
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+// ─── Shimmer brush ───────────────────────────────────────────────────────────
+
+private fun Modifier.shimmerEffect(): Modifier = composed {
+    val transition = rememberInfiniteTransition(label = "shimmer")
+    val translateAnim by transition.animateFloat(
+        initialValue = 0f,
+        targetValue = 1000f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(durationMillis = 1200, easing = LinearEasing),
+            repeatMode = RepeatMode.Restart,
+        ),
+        label = "shimmerTranslate",
+    )
+    val shimmerColors = listOf(
+        MaterialTheme.colorScheme.surfaceVariant,
+        MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.4f),
+        MaterialTheme.colorScheme.surfaceVariant,
+    )
+    background(
+        brush = Brush.linearGradient(
+            colors = shimmerColors,
+            start = Offset(translateAnim - 300f, 0f),
+            end = Offset(translateAnim, 0f),
+        ),
+        shape = RoundedCornerShape(4.dp),
+    )
+}
+
+@Composable
+private fun SkeletonBox(width: Dp, height: Dp, modifier: Modifier = Modifier) {
+    Box(
+        modifier = modifier
+            .width(width)
+            .height(height)
+            .shimmerEffect()
+    )
+}
+
+@Composable
+private fun SkeletonFill(height: Dp, modifier: Modifier = Modifier) {
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(height)
+            .shimmerEffect()
+    )
+}
+
+// ─── AccountInfo skeleton ────────────────────────────────────────────────────
+
+@Composable
+fun AccountInfoSkeleton() {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween,
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 8.dp)
+            .padding(bottom = 8.dp)
+    ) {
+        Column {
+            // 총자산 + refresh icon placeholder
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                SkeletonBox(width = 140.dp, height = 28.dp)
+                Spacer(Modifier.width(8.dp))
+                SkeletonBox(width = 24.dp, height = 24.dp)
+            }
+            Spacer(Modifier.height(6.dp))
+            // 수익/수익률
+            SkeletonBox(width = 110.dp, height = 16.dp)
+        }
+        // toggle button
+        SkeletonBox(width = 80.dp, height = 32.dp)
+    }
+
+    // 예수금 헤더
+    Row(modifier = Modifier.padding(horizontal = 16.dp)) {
+        repeat(3) {
+            SkeletonBox(width = 60.dp, height = 14.dp, modifier = Modifier.weight(1f))
+        }
+    }
+    Spacer(Modifier.height(4.dp))
+    // 예수금 값
+    Row(modifier = Modifier.padding(horizontal = 16.dp)) {
+        repeat(3) {
+            SkeletonBox(width = 70.dp, height = 16.dp, modifier = Modifier.weight(1f))
+        }
+    }
+    Spacer(Modifier.height(8.dp))
+}
+
+// ─── HomeStockItem skeleton ──────────────────────────────────────────────────
+
+@Composable
+fun HomeStockItemSkeleton() {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween,
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(8.dp)
+    ) {
+        Column {
+            SkeletonBox(width = 100.dp, height = 16.dp)
+            Spacer(Modifier.height(4.dp))
+            SkeletonBox(width = 80.dp, height = 14.dp)
+        }
+        Column(horizontalAlignment = Alignment.End) {
+            SkeletonBox(width = 80.dp, height = 16.dp)
+            Spacer(Modifier.height(4.dp))
+            SkeletonBox(width = 100.dp, height = 14.dp)
+        }
+    }
+}
+
+// ─── Full home skeleton ──────────────────────────────────────────────────────
+
+@Composable
+fun HomeLoadingSkeleton(modifier: Modifier = Modifier) {
+    LazyColumn(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(top = 8.dp)
+    ) {
+        item { AccountInfoSkeleton() }
+        // 종목 스켈레톤 5개
+        items(5) { HomeStockItemSkeleton() }
+    }
+}


### PR DESCRIPTION
## 변경 사항

### 신규: `HomeSkeleton.kt`
- shimmer 애니메이션 기반 스켈레톤 컴포저블
- `AccountInfoSkeleton()` — 총자산/수익/예수금 영역
- `HomeStockItemSkeleton()` — 종목 행
- `HomeLoadingSkeleton()` — 전체 초기 로딩 화면 (5개 종목)

### 수정: `HomeScreen.kt`
- `loading=true && userStocks=null` (초기 로딩) → 스켈레톤 전체 화면
- `loading=true && userStocks!=null` (새로고침 중) → 기존 데이터 유지 + 리스트 상단 작은 spinner