### PR TITLE
스팩 종목 주문 시 거래소 KRX 고정

### DIFF
--- a/app/src/main/java/com/trueedu/project/repository/remote/OrderRemote.kt
+++ b/app/src/main/java/com/trueedu/project/repository/remote/OrderRemote.kt
@@ -19,6 +19,7 @@ interface OrderRemote {
         code: String,
         price: String,
         quantity: String,
+        isSpac: Boolean = false,
     ): Flow<OrderResponse>
 
     fun sell(
@@ -26,6 +27,7 @@ interface OrderRemote {
         code: String,
         price: String,
         quantity: String,
+        isSpac: Boolean = false,
     ): Flow<OrderResponse>
 
     fun modifiable(accountNum: String): Flow<OrderModifiableResponse>

--- a/app/src/main/java/com/trueedu/project/repository/remote/OrderRemoteImpl.kt
+++ b/app/src/main/java/com/trueedu/project/repository/remote/OrderRemoteImpl.kt
@@ -18,6 +18,7 @@ class OrderRemoteImpl(
         code: String,
         price: String,
         quantity: String,
+        isSpac: Boolean,
     ): Flow<OrderResponse> {
         return buySell(
             isBuy = true,
@@ -25,6 +26,7 @@ class OrderRemoteImpl(
             code = code,
             price = price,
             quantity = quantity,
+            isSpac = isSpac,
         )
     }
 
@@ -33,6 +35,7 @@ class OrderRemoteImpl(
         code: String,
         price: String,
         quantity: String,
+        isSpac: Boolean,
     ): Flow<OrderResponse> {
         return buySell(
             isBuy = false,
@@ -40,6 +43,7 @@ class OrderRemoteImpl(
             code = code,
             price = price,
             quantity = quantity,
+            isSpac = isSpac,
         )
     }
 
@@ -49,6 +53,7 @@ class OrderRemoteImpl(
         code: String,
         price: String,
         quantity: String,
+        isSpac: Boolean = false,
     ) = apiCallFlow {
 
         // 현금 매수, 현금 매도
@@ -84,9 +89,10 @@ class OrderRemoteImpl(
             "ORD_DVSN" to "00", // 주문 구분 - 일단 지정가로 주문하기
             "ORD_QTY" to quantity, // 주문 수량
             "ORD_UNPR" to price, // 주문 단가
-            "EXCG_ID_DVSN_CD" to "SOR", // 한국거래소 : KRX (기본값)
+            "EXCG_ID_DVSN_CD" to if (isSpac) "KRX" else "SOR", // 한국거래소 : KRX (기본값)
                                         // 대체거래소 (넥스트레이드) : NXT
                                         // SOR (Smart Order Routing) : SOR
+                                        // 스팩은 KRX 거래소에만 상장되므로 KRX 고정
         )
         orderService.buy(headers, body)
     }

--- a/app/src/main/java/com/trueedu/project/ui/views/order/OrderViewModel.kt
+++ b/app/src/main/java/com/trueedu/project/ui/views/order/OrderViewModel.kt
@@ -140,12 +140,14 @@ class OrderViewModel @Inject constructor(
             logD("order failed: empty accountNum")
         }
 
+        val isSpac = stockPool.get(code)?.spac() ?: false
         if (isBuy) {
             orderRemote.buy(
                 accountNum = userKey.accountNum!!,
                 code = code,
                 price = priceInput.value.text,
                 quantity = quantityInput.value.text,
+                isSpac = isSpac,
             )
         } else{
             orderRemote.sell(
@@ -153,6 +155,7 @@ class OrderViewModel @Inject constructor(
                 code = code,
                 price = priceInput.value.text,
                 quantity = quantityInput.value.text,
+                isSpac = isSpac,
             )
         }
             .flowOn(Dispatchers.IO)


### PR DESCRIPTION
스팩은 KRX에만 상장되어 있으므로, 스팩 종목 주문 시 `EXCG_ID_DVSN_CD`를 SOR 대신 KRX로 고정합니다.

## 변경 내용
- `OrderRemote` buy/sell에 `isSpac: Boolean = false` 파라미터 추가
- `OrderRemoteImpl`에서 스팩 여부에 따라 `EXCG_ID_DVSN_CD` 분기 처리 (`KRX` vs `SOR`)
- `OrderViewModel`에서 `stockPool.get(code)?.spac()`으로 스팩 여부 판별 후 전달