### PR TITLE
fix: 주문 화면 웹소켓 연결 안정화 (호가 실시간 수신 불가 버그)

### DIFF
--- a/app/src/main/java/com/trueedu/project/data/TokenKeyManager.kt
+++ b/app/src/main/java/com/trueedu/project/data/TokenKeyManager.kt
@@ -88,6 +88,20 @@ class TokenKeyManager @Inject constructor(
             logD("appKey appSecret is empty")
             return
         }
+        requestWebSocketKey(appKey, appSecret)
+    }
+
+    /** approval key 만료/무효 시 강제 재발급 */
+    fun reissueWebSocketKey() {
+        val appKey = userKey.value?.appKey ?: return
+        val appSecret = userKey.value?.appSecret ?: return
+        if (appKey.isEmpty() || appSecret.isEmpty()) return
+        logD("reissueWebSocketKey()")
+        local.webSocketKey = ""
+        requestWebSocketKey(appKey, appSecret)
+    }
+
+    private fun requestWebSocketKey(appKey: String, appSecret: String) {
         val request = WebSocketKeyRequest(
             grantType = "client_credentials",
             appKey = appKey,

--- a/app/src/main/java/com/trueedu/project/data/realtime/RealOrderManager.kt
+++ b/app/src/main/java/com/trueedu/project/data/realtime/RealOrderManager.kt
@@ -1,6 +1,7 @@
 package com.trueedu.project.data.realtime
 
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.snapshotFlow
 import com.trueedu.project.data.log.logD
 import com.trueedu.project.model.ws.RealTimeOrder
 import com.trueedu.project.model.ws.TransactionId
@@ -50,6 +51,16 @@ class RealOrderManager @Inject constructor(
     fun start() {
         job = MainScope().launch(Dispatchers.IO) {
             launch {
+                // 웹소켓 연결/재연결 시 자동으로 호가 구독 재시도
+                snapshotFlow { wsMessageHandler.on.value }
+                    .collect { isConnected ->
+                        if (isConnected && code != null) {
+                            logD("websocket reconnected - resume quotes request for $code")
+                            beginRequests(code!!)
+                        }
+                    }
+            }
+            launch {
                 wsMessageHandler.observeEvent()
                     .filter {
                         it.header.transactionId == TransactionId.RealTimeQuotes ||
@@ -67,9 +78,6 @@ class RealOrderManager @Inject constructor(
                         data.value = it
                     }
             }
-        }
-        if (code != null) {
-            beginRequests(code!!)
         }
     }
 

--- a/app/src/main/java/com/trueedu/project/data/realtime/WsMessageHandler.kt
+++ b/app/src/main/java/com/trueedu/project/data/realtime/WsMessageHandler.kt
@@ -113,6 +113,16 @@ class WsMessageHandler @Inject constructor(
                     val res = WsResponse.from(text)
                     logD("transactionId ${res.header.transactionId}")
 
+                    // approval key 만료/무효 시 키 재발급 후 재연결
+                    if (res.body?.returnCode == "1" && res.body.msgCode == "OPSP0011") {
+                        logD("invalid approval key - reissue and reconnect")
+                        local.webSocketKey = ""
+                        MainScope().launch {
+                            tokenKeyManager.reissueWebSocketKey()
+                        }
+                        return
+                    }
+
                     when (res.header.transactionId) {
                         TransactionId.PingPong -> webSocketService.sendMessage(text)
                         TransactionId.RealTimeQuotes,

--- a/app/src/main/java/com/trueedu/project/di/AppQualifier.kt
+++ b/app/src/main/java/com/trueedu/project/di/AppQualifier.kt
@@ -41,3 +41,7 @@ annotation class KisOkHttp
 @Qualifier
 @Retention(AnnotationRetention.BINARY)
 annotation class DartOkHttp
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class WebSocketOkHttp

--- a/app/src/main/java/com/trueedu/project/di/NetworkModule.kt
+++ b/app/src/main/java/com/trueedu/project/di/NetworkModule.kt
@@ -182,11 +182,40 @@ object NetworkModule {
 
     // websocket 관련
 
+    /**
+     * 웹소켓 전용 OkHttpClient
+     * - callTimeout/readTimeout/writeTimeout 을 0(무제한)으로 설정해야 long-lived connection 유지 가능
+     * - KisOkHttp 클라이언트(20초 타임아웃)를 그대로 사용하면 비활성 구간에 timeout onFailure 발생
+     */
+    @Provides
+    @Singleton
+    @WebSocketOkHttp
+    fun provideWebSocketOkHttpClient(
+        loggingInterceptor: HttpLoggingInterceptor,
+        chuckerInterceptor: ChuckerInterceptor,
+        flipperOkhttpInterceptor: FlipperOkhttpInterceptor,
+    ): OkHttpClient {
+        return OkHttpClient.Builder()
+            .apply {
+                if (BuildConfig.DEBUG) {
+                    addHttpLoggingInterceptor()
+                }
+            }
+            .addInterceptor(loggingInterceptor)
+            .addInterceptor(chuckerInterceptor)
+            .addNetworkInterceptor(flipperOkhttpInterceptor)
+            .connectTimeout(connectTimeout.toJavaDuration())
+            .callTimeout(0, java.util.concurrent.TimeUnit.SECONDS)   // 무제한
+            .readTimeout(0, java.util.concurrent.TimeUnit.SECONDS)    // 무제한
+            .writeTimeout(writeTimeout.toJavaDuration())
+            .build()
+    }
+
     @Provides
     @Singleton
     fun provideWebSocketService(
         @WebSocketUrl webSocketUrl: String,
-        @KisOkHttp okHttpClient: OkHttpClient,
+        @WebSocketOkHttp okHttpClient: OkHttpClient,
     ): WebSocketService {
         return MyWebSocketService(webSocketUrl, okHttpClient)
     }


### PR DESCRIPTION
## 문제

주문 화면에서 실시간 호가 데이터를 수신하지 못하는 버그.
`wsMessageHandler.on` 값이 `false`로 유지되어 호가 구독 자체가 이뤄지지 않았음.

## 원인

### 1. WebSocket에 REST용 OkHttpClient 사용 (핵심 원인)
`WebSocketService`가 KIS REST API용 `@KisOkHttp` 클라이언트를 그대로 사용하고 있었음.
해당 클라이언트에는 `callTimeout = 20초`, `readTimeout = 20초`가 설정되어 있어,
20초 동안 메시지가 없으면 OkHttp가 timeout으로 `onFailure`를 발생시킴.
→ 재연결 시도 → 또 20초 후 실패 → `on.value`가 항상 `false`

### 2. RealOrderManager의 웹소켓 재연결 시 호가 재구독 누락
`RealPriceManager`(체결가)는 `wsMessageHandler.on`을 관찰해 재연결 시 자동 재구독하지만,
`RealOrderManager`(호가)에는 이 로직이 없었음.

## 수정

### `NetworkModule.kt` + `AppQualifier.kt`
웹소켓 전용 `@WebSocketOkHttp` OkHttpClient 분리:
- `callTimeout = 0` (무제한)
- `readTimeout = 0` (무제한)
- REST 전용 인터셉터(TokenInterceptor 등) 제거

### `RealOrderManager.kt`
웹소켓 재연결 감지 시 호가 구독 자동 재시도 로직 추가:
```kotlin
snapshotFlow { wsMessageHandler.on.value }
    .collect { isConnected ->
        if (isConnected && code != null) {
            beginRequests(code!!)
        }
    }
```