### PR TITLE
fix: 웹소켓 approval key 만료(OPSP0011) 시 자동 재발급

### DIFF
--- a/app/src/main/java/com/trueedu/project/data/TokenKeyManager.kt
+++ b/app/src/main/java/com/trueedu/project/data/TokenKeyManager.kt
@@ -88,6 +88,20 @@ class TokenKeyManager @Inject constructor(
             logD("appKey appSecret is empty")
             return
         }
+        requestWebSocketKey(appKey, appSecret)
+    }
+
+    /** approval key 만료/무효 시 강제 재발급 */
+    fun reissueWebSocketKey() {
+        val appKey = userKey.value?.appKey ?: return
+        val appSecret = userKey.value?.appSecret ?: return
+        if (appKey.isEmpty() || appSecret.isEmpty()) return
+        logD("reissueWebSocketKey()")
+        local.webSocketKey = ""
+        requestWebSocketKey(appKey, appSecret)
+    }
+
+    private fun requestWebSocketKey(appKey: String, appSecret: String) {
         val request = WebSocketKeyRequest(
             grantType = "client_credentials",
             appKey = appKey,

--- a/app/src/main/java/com/trueedu/project/data/realtime/WsMessageHandler.kt
+++ b/app/src/main/java/com/trueedu/project/data/realtime/WsMessageHandler.kt
@@ -97,6 +97,12 @@ class WsMessageHandler @Inject constructor(
 
         if (!foreground) return
 
+        // 이미 연결된 상태면 재연결 불필요
+        if (on.value) {
+            logD("already connected, skip")
+            return
+        }
+
         webSocketService.disconnect()
         webSocketService.connect(object: WebSocketListener() {
             override fun onOpen(webSocket: WebSocket, response: Response) {

--- a/app/src/main/java/com/trueedu/project/data/realtime/WsMessageHandler.kt
+++ b/app/src/main/java/com/trueedu/project/data/realtime/WsMessageHandler.kt
@@ -113,6 +113,16 @@ class WsMessageHandler @Inject constructor(
                     val res = WsResponse.from(text)
                     logD("transactionId ${res.header.transactionId}")
 
+                    // approval key 만료/무효 시 키 재발급 후 재연결
+                    if (res.body?.returnCode == "1" && res.body.msgCode == "OPSP0011") {
+                        logD("invalid approval key - reissue and reconnect")
+                        local.webSocketKey = ""
+                        MainScope().launch {
+                            tokenKeyManager.reissueWebSocketKey()
+                        }
+                        return
+                    }
+
                     when (res.header.transactionId) {
                         TransactionId.PingPong -> webSocketService.sendMessage(text)
                         TransactionId.RealTimeQuotes,


### PR DESCRIPTION
## 문제

웹소켓 연결 후 서버로부터 `OPSP0011 invalid approval` 응답이 오며 즉시 연결이 끊어짐.
`EOFException`이 반복되며 연결/실패 루프 발생.

## 원인

SharedPreferences에 만료된 WebSocket approval key가 남아있는 상태에서,
`issueWebSocketKey()`는 키가 존재하면 재발급을 하지 않음.
→ 앱 재시작 후에도 무효 키로 연결 시도 반복.

## 수정

### `WsMessageHandler.kt`
`onMessage`에서 `OPSP0011` 응답 감지 시 키 초기화 후 재발급 요청:
```kotlin
if (res.body?.returnCode == "1" && res.body.msgCode == "OPSP0011") {
    local.webSocketKey = ""
    tokenKeyManager.reissueWebSocketKey()
    return
}
```

### `TokenKeyManager.kt`
강제 재발급 public 함수 추가 및 내부 코드 정리:
- `reissueWebSocketKey()`: 키를 무조건 초기화하고 재발급
- `requestWebSocketKey()`: 실제 API 호출 로직을 분리