### PR TITLE
IRP 퇴직연금 계좌 홈 화면 지원

### DIFF
--- a/app/src/main/java/com/trueedu/project/MainViewModel.kt
+++ b/app/src/main/java/com/trueedu/project/MainViewModel.kt
@@ -12,6 +12,7 @@ import com.trueedu.project.data.UserAssets
 import com.trueedu.project.data.log.logD
 import com.trueedu.project.model.dto.account.AccountResponse
 import com.trueedu.project.model.dto.account.PensionAccountResponse
+import com.trueedu.project.model.dto.account.PensionFundResponse
 import com.trueedu.project.data.firebase.FirebaseRealtimeDatabase
 import com.trueedu.project.model.dto.account.AccountAsset
 import com.trueedu.project.model.dto.firebase.AppNotice
@@ -38,6 +39,7 @@ class MainViewModel @Inject constructor(
     val accountNum = mutableStateOf("")
     val userStocks = mutableStateOf<AccountResponse?>(null)
     val pensionStocks = mutableStateOf<PensionAccountResponse?>(null)
+    val pensionFundStocks = mutableStateOf<PensionFundResponse?>(null)
     val marketPriceMode = mutableStateOf(local.marketPriceMode)
     val forceUpdateVisible = mutableStateOf(false)
 
@@ -81,6 +83,11 @@ class MainViewModel @Inject constructor(
                 }
             }
             launch {
+                userAssets.pensionFundAssets.collectLatest {
+                    pensionFundStocks.value = it
+                }
+            }
+            launch {
                 googleAccount.loginSignal
                     .collect {
                         googleSignInAccount.value = googleAccount.googleSignInAccount
@@ -113,6 +120,10 @@ class MainViewModel @Inject constructor(
         userAssets.loadPensionStocks(
             accountNum = accountNum,
             onSuccess = onSuccess,
+            onFail = {},
+        )
+        userAssets.loadPensionFundStocks(
+            accountNum = accountNum,
             onFail = {},
         )
     }

--- a/app/src/main/java/com/trueedu/project/MainViewModel.kt
+++ b/app/src/main/java/com/trueedu/project/MainViewModel.kt
@@ -11,6 +11,7 @@ import com.trueedu.project.data.TokenKeyManager
 import com.trueedu.project.data.UserAssets
 import com.trueedu.project.data.log.logD
 import com.trueedu.project.model.dto.account.AccountResponse
+import com.trueedu.project.model.dto.account.PensionAccountResponse
 import com.trueedu.project.data.firebase.FirebaseRealtimeDatabase
 import com.trueedu.project.model.dto.account.AccountAsset
 import com.trueedu.project.model.dto.firebase.AppNotice
@@ -36,6 +37,7 @@ class MainViewModel @Inject constructor(
     val googleSignInAccount = mutableStateOf<GoogleSignInAccount?>(null)
     val accountNum = mutableStateOf("")
     val userStocks = mutableStateOf<AccountResponse?>(null)
+    val pensionStocks = mutableStateOf<PensionAccountResponse?>(null)
     val marketPriceMode = mutableStateOf(local.marketPriceMode)
     val forceUpdateVisible = mutableStateOf(false)
 
@@ -74,6 +76,11 @@ class MainViewModel @Inject constructor(
                 }
             }
             launch {
+                userAssets.pensionAssets.collectLatest {
+                    pensionStocks.value = it
+                }
+            }
+            launch {
                 googleAccount.loginSignal
                     .collect {
                         googleSignInAccount.value = googleAccount.googleSignInAccount
@@ -100,6 +107,19 @@ class MainViewModel @Inject constructor(
             onFail = {
             }
         )
+    }
+
+    fun refreshPension(accountNum: String, onSuccess: () -> Unit = {}) {
+        userAssets.loadPensionStocks(
+            accountNum = accountNum,
+            onSuccess = onSuccess,
+            onFail = {},
+        )
+    }
+
+    fun isPensionAccount(accountNum: String): Boolean {
+        // 계좌번호 끝 2자리가 29이면 IRP 계좌
+        return accountNum.length >= 2 && accountNum.takeLast(2) == "29"
     }
 
     fun onChangeMarketPriceMode(selected: Int) {

--- a/app/src/main/java/com/trueedu/project/data/UserAssets.kt
+++ b/app/src/main/java/com/trueedu/project/data/UserAssets.kt
@@ -2,6 +2,7 @@ package com.trueedu.project.data
 
 import com.trueedu.project.data.log.logD
 import com.trueedu.project.model.dto.account.AccountResponse
+import com.trueedu.project.model.dto.account.PensionAccountResponse
 import com.trueedu.project.model.event.TokenIssued
 import com.trueedu.project.model.event.TokenOk
 import com.trueedu.project.repository.remote.AccountRemote
@@ -24,20 +25,84 @@ class UserAssets @Inject constructor(
 ) {
     var job: Job? = null
     val assets = MutableSharedFlow<AccountResponse>(1)
+    val pensionAssets = MutableSharedFlow<PensionAccountResponse>(1)
+
+    private fun isPensionAccount(accountNum: String): Boolean {
+        return accountNum.length >= 2 && accountNum.takeLast(2) == "29"
+    }
+
+    private fun loadAccountData(accountNum: String) {
+        if (isPensionAccount(accountNum)) {
+            loadPensionStocks(accountNum)
+        } else {
+            loadUserStocks()
+        }
+    }
 
     // 앱이 foreground 상태가 될 때
     fun start() {
         logD("start")
-        loadUserStocks()
+        val accountNum = tokenKeyManager.userKey.value?.accountNum ?: ""
+        loadAccountData(accountNum)
 
         job = MainScope().launch {
             tokenKeyManager.observeTokenKeyEvent()
                 .collect {
                     if (it is TokenOk || it is TokenIssued) {
-                        loadUserStocks()
+                        val num = tokenKeyManager.userKey.value?.accountNum ?: ""
+                        loadAccountData(num)
                     }
                 }
         }
+    }
+
+    fun loadPensionStocks(
+        accountNum: String,
+        onSuccess: () -> Unit = {},
+        onFail: (Throwable) -> Unit = {},
+    ) {
+        accountRemote.getPensionStocks(accountNum)
+            .flowOn(Dispatchers.IO)
+            .catch {
+                onFail(it)
+            }
+            .onEach {
+                if (it.fk100.isNotEmpty() && it.nk100.isNotEmpty() && it.output1.size >= 50) {
+                    loadPensionNext(it, accountNum, it.fk100, it.nk100, onSuccess, onFail)
+                } else {
+                    pensionAssets.emit(it)
+                    onSuccess()
+                }
+            }
+            .flowOn(Dispatchers.Main)
+            .launchIn(MainScope())
+    }
+
+    private fun loadPensionNext(
+        prevResult: PensionAccountResponse,
+        accountNum: String,
+        fk100: String,
+        nk100: String,
+        onSuccess: () -> Unit = {},
+        onFail: (Throwable) -> Unit = {},
+    ) {
+        accountRemote.getPensionStocks(accountNum, fk100, nk100)
+            .flowOn(Dispatchers.IO)
+            .catch {
+                onFail(it)
+            }
+            .onEach {
+                val output1 = prevResult.output1 + it.output1
+                val result = it.copy(output1 = output1)
+                if (it.fk100.isNotEmpty() && it.nk100.isNotEmpty() && it.output1.size >= 50) {
+                    loadPensionNext(result, accountNum, it.fk100, it.nk100, onSuccess, onFail)
+                } else {
+                    pensionAssets.emit(result)
+                    onSuccess()
+                }
+            }
+            .flowOn(Dispatchers.Main)
+            .launchIn(MainScope())
     }
 
     // 앱이 background 상태가 될 때

--- a/app/src/main/java/com/trueedu/project/data/UserAssets.kt
+++ b/app/src/main/java/com/trueedu/project/data/UserAssets.kt
@@ -3,6 +3,7 @@ package com.trueedu.project.data
 import com.trueedu.project.data.log.logD
 import com.trueedu.project.model.dto.account.AccountResponse
 import com.trueedu.project.model.dto.account.PensionAccountResponse
+import com.trueedu.project.model.dto.account.PensionFundResponse
 import com.trueedu.project.model.event.TokenIssued
 import com.trueedu.project.model.event.TokenOk
 import com.trueedu.project.repository.remote.AccountRemote
@@ -26,6 +27,7 @@ class UserAssets @Inject constructor(
     var job: Job? = null
     val assets = MutableSharedFlow<AccountResponse>(1)
     val pensionAssets = MutableSharedFlow<PensionAccountResponse>(1)
+    val pensionFundAssets = MutableSharedFlow<PensionFundResponse>(1)
 
     private fun isPensionAccount(accountNum: String): Boolean {
         return accountNum.length >= 2 && accountNum.takeLast(2) == "29"
@@ -34,6 +36,7 @@ class UserAssets @Inject constructor(
     private fun loadAccountData(accountNum: String) {
         if (isPensionAccount(accountNum)) {
             loadPensionStocks(accountNum)
+            loadPensionFundStocks(accountNum)
         } else {
             loadUserStocks()
         }
@@ -71,6 +74,51 @@ class UserAssets @Inject constructor(
                     loadPensionNext(it, accountNum, it.fk100, it.nk100, onSuccess, onFail)
                 } else {
                     pensionAssets.emit(it)
+                    onSuccess()
+                }
+            }
+            .flowOn(Dispatchers.Main)
+            .launchIn(MainScope())
+    }
+
+    fun loadPensionFundStocks(
+        accountNum: String,
+        onSuccess: () -> Unit = {},
+        onFail: (Throwable) -> Unit = {},
+    ) {
+        accountRemote.getPensionFundStocks(accountNum)
+            .flowOn(Dispatchers.IO)
+            .catch { onFail(it) }
+            .onEach {
+                if (it.fk100.isNotEmpty() && it.nk100.isNotEmpty() && it.output1.size >= 50) {
+                    loadPensionFundNext(it, accountNum, it.fk100, it.nk100, onSuccess, onFail)
+                } else {
+                    pensionFundAssets.emit(it)
+                    onSuccess()
+                }
+            }
+            .flowOn(Dispatchers.Main)
+            .launchIn(MainScope())
+    }
+
+    private fun loadPensionFundNext(
+        prevResult: PensionFundResponse,
+        accountNum: String,
+        fk100: String,
+        nk100: String,
+        onSuccess: () -> Unit = {},
+        onFail: (Throwable) -> Unit = {},
+    ) {
+        accountRemote.getPensionFundStocks(accountNum, fk100, nk100)
+            .flowOn(Dispatchers.IO)
+            .catch { onFail(it) }
+            .onEach {
+                val output1 = prevResult.output1 + it.output1
+                val result = it.copy(output1 = output1)
+                if (it.fk100.isNotEmpty() && it.nk100.isNotEmpty() && it.output1.size >= 50) {
+                    loadPensionFundNext(result, accountNum, it.fk100, it.nk100, onSuccess, onFail)
+                } else {
+                    pensionFundAssets.emit(result)
                     onSuccess()
                 }
             }

--- a/app/src/main/java/com/trueedu/project/model/dto/account/PensionAccountResponse.kt
+++ b/app/src/main/java/com/trueedu/project/model/dto/account/PensionAccountResponse.kt
@@ -1,0 +1,93 @@
+package com.trueedu.project.model.dto.account
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class PensionAccountResponse(
+    val output1: List<PensionAsset>,
+    val output2: PensionDetail,
+    @SerialName("rt_cd")
+    val rtCd: String, // 성공 실패 여부 "0" 성공
+    @SerialName("msg_cd")
+    val msgCd: String, // 응답코드
+    val msg1: String, // 응답메세지
+
+    // 다음 연속 조회시 사용
+    @SerialName("ctx_area_fk100")
+    val fk100: String, // 연속조회검색조건100
+    @SerialName("ctx_area_nk100")
+    val nk100: String, // 연속조회키100
+)
+
+@Serializable
+data class PensionAsset(
+    @SerialName("pdno")
+    val code: String, // 상품번호 (종목코드)
+    @SerialName("prdt_name")
+    val nameKr: String, // 상품명
+    @SerialName("cblc_dvsn_name")
+    val balanceDivisionName: String, // 잔고구분명
+    @SerialName("item_dvsn_name")
+    val itemDivisionName: String, // 종목구분명
+    @SerialName("thdt_buyqty")
+    val todayBuyQuantity: String, // 금일매수수량
+    @SerialName("thdt_sll_qty")
+    val todaySellQuantity: String, // 금일매도수량
+    @SerialName("hldg_qty")
+    val holdingQuantity: String, // 보유수량
+    @SerialName("ord_psbl_qty")
+    val orderPossibleQuantity: String, // 주문가능수량
+    @SerialName("pchs_avg_pric")
+    val purchaseAveragePrice: String, // 매입평균가격
+    @SerialName("pchs_amt")
+    val purchaseAmount: String, // 매입금액
+    @SerialName("prpr")
+    val currentPrice: String, // 현재가
+    @SerialName("evlu_amt")
+    val evaluationAmount: String, // 평가금액
+    @SerialName("evlu_pfls_amt")
+    val profitLossAmount: String, // 평가손익금액
+    @SerialName("evlu_erng_rt")
+    val evaluationEarningsRate: String, // 평가수익율
+)
+
+@Serializable
+data class PensionDetail(
+    @SerialName("dnca_tot_amt")
+    val depositAccountTotalAmount: String, // 예수금총금액
+    @SerialName("nxdy_excc_amt")
+    val nextDayExcessAmount: String, // 익일정산금액 - D+1 예수금
+    @SerialName("prvs_rcdl_excc_amt")
+    val previousRedemptionExcessAmount: String, // 가수도정산금액 - D+2 예수금
+    @SerialName("thdt_buy_amt")
+    val todayBuyAmount: String, // 금일매수금액
+    @SerialName("thdt_sll_amt")
+    val todaySellAmount: String, // 금일매도금액
+    @SerialName("thdt_tlex_amt")
+    val todayTotalExpensesAmount: String, // 금일제비용금액
+    @SerialName("scts_evlu_amt")
+    val stockEvaluationAmount: String, // 유가평가금액
+    @SerialName("tot_evlu_amt")
+    val totalEvaluationAmount: String, // 총평가금액
+) {
+    // 총손익금액 — output2에 없으므로 output1 items에서 합산
+    // 총수익률 — output1 items의 pchs_amt 합계 기준으로 계산
+    fun totalProfitRate(items: List<PensionAsset>): Double {
+        return try {
+            val cost = items.sumOf { it.purchaseAmount.toDouble() }
+            val value = items.sumOf { it.evaluationAmount.toDouble() }
+            if (cost == 0.0) 0.0 else (value - cost) / cost * 100
+        } catch (_: NumberFormatException) {
+            0.0
+        }
+    }
+
+    fun totalProfitAmount(items: List<PensionAsset>): Double {
+        return try {
+            items.sumOf { it.profitLossAmount.toDouble() }
+        } catch (_: NumberFormatException) {
+            0.0
+        }
+    }
+}

--- a/app/src/main/java/com/trueedu/project/model/dto/account/PensionFundResponse.kt
+++ b/app/src/main/java/com/trueedu/project/model/dto/account/PensionFundResponse.kt
@@ -1,0 +1,67 @@
+package com.trueedu.project.model.dto.account
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class PensionFundResponse(
+    val output1: List<PensionFundAsset>,
+    val output2: List<PensionFundDetail>,
+    @SerialName("rt_cd")
+    val rtCd: String, // 성공 실패 여부 "0" 성공
+    @SerialName("msg_cd")
+    val msgCd: String, // 응답코드
+    val msg1: String, // 응답메세지
+
+    // 다음 연속 조회시 사용
+    @SerialName("ctx_area_fk100")
+    val fk100: String,
+    @SerialName("ctx_area_nk100")
+    val nk100: String,
+)
+
+@Serializable
+data class PensionFundAsset(
+    @SerialName("cblc_dvsn")
+    val balanceDivision: String, // 잔고구분
+    @SerialName("cblc_dvsn_name")
+    val balanceDivisionName: String, // 잔고구분명
+    @SerialName("pdno")
+    val code: String, // 상품번호 (펀드코드)
+    @SerialName("prdt_name")
+    val nameKr: String, // 상품명
+    @SerialName("hldg_qty")
+    val holdingQuantity: String, // 보유수량
+    @SerialName("slpsb_qty")
+    val sellPossibleQuantity: String, // 매도가능수량
+    @SerialName("pchs_avg_pric")
+    val purchaseAveragePrice: String, // 매입평균가격
+    @SerialName("evlu_pfls_amt")
+    val profitLossAmount: String, // 평가손익금액
+    @SerialName("evlu_pfls_rt")
+    val profitLossRate: String, // 평가손익율
+    @SerialName("prpr")
+    val currentPrice: String, // 현재가 (기준가)
+    @SerialName("evlu_amt")
+    val evaluationAmount: String, // 평가금액
+    @SerialName("pchs_amt")
+    val purchaseAmount: String, // 매입금액
+    @SerialName("cblc_weit")
+    val balanceWeight: String, // 잔고비중
+)
+
+@Serializable
+data class PensionFundDetail(
+    @SerialName("pchs_amt_smtl_amt")
+    val purchaseAmountSumTotalAmount: String, // 매입금액합계금액
+    @SerialName("evlu_amt_smtl_amt")
+    val evaluationAmountSumTotalAmount: String, // 평가금액합계금액
+    @SerialName("evlu_pfls_smtl_amt")
+    val profitLossSumTotalAmount: String, // 평가손익합계금액
+    @SerialName("trad_pfls_smtl")
+    val tradeProfitLossSum: String, // 매매손익합계
+    @SerialName("thdt_tot_pfls_amt")
+    val todayTotalProfitLossAmount: String, // 당일총손익금액
+    @SerialName("pftrt")
+    val profitRate: String, // 수익률
+)

--- a/app/src/main/java/com/trueedu/project/repository/remote/AccountRemote.kt
+++ b/app/src/main/java/com/trueedu/project/repository/remote/AccountRemote.kt
@@ -2,6 +2,7 @@ package com.trueedu.project.repository.remote
 
 import com.trueedu.project.model.dto.account.AccountResponse
 import com.trueedu.project.model.dto.account.PensionAccountResponse
+import com.trueedu.project.model.dto.account.PensionFundResponse
 import kotlinx.coroutines.flow.Flow
 
 interface AccountRemote {
@@ -16,4 +17,10 @@ interface AccountRemote {
         fk100: String = "",
         nk100: String = "",
     ): Flow<PensionAccountResponse>
+
+    fun getPensionFundStocks(
+        accountNum: String,
+        fk100: String = "",
+        nk100: String = "",
+    ): Flow<PensionFundResponse>
 }

--- a/app/src/main/java/com/trueedu/project/repository/remote/AccountRemote.kt
+++ b/app/src/main/java/com/trueedu/project/repository/remote/AccountRemote.kt
@@ -1,6 +1,7 @@
 package com.trueedu.project.repository.remote
 
 import com.trueedu.project.model.dto.account.AccountResponse
+import com.trueedu.project.model.dto.account.PensionAccountResponse
 import kotlinx.coroutines.flow.Flow
 
 interface AccountRemote {
@@ -9,4 +10,10 @@ interface AccountRemote {
         fk100: String = "",
         nk100: String = "",
     ): Flow<AccountResponse>
+
+    fun getPensionStocks(
+        accountNum: String,
+        fk100: String = "",
+        nk100: String = "",
+    ): Flow<PensionAccountResponse>
 }

--- a/app/src/main/java/com/trueedu/project/repository/remote/AccountRemoteImpl.kt
+++ b/app/src/main/java/com/trueedu/project/repository/remote/AccountRemoteImpl.kt
@@ -4,6 +4,7 @@ import com.trueedu.project.di.NormalService
 import com.trueedu.project.network.apiCallFlow
 import com.trueedu.project.repository.remote.service.AccountService
 
+
 class AccountRemoteImpl(
     @NormalService
     private val accountService: AccountService
@@ -58,5 +59,25 @@ class AccountRemoteImpl(
             "CTX_AREA_NK100" to nk100,
         )
         accountService.getPensionAccount(headers, queries)
+    }
+
+    override fun getPensionFundStocks(
+        accountNum: String,
+        fk100: String,
+        nk100: String,
+    ) = apiCallFlow {
+        val tc = if (fk100.isEmpty() || nk100.isEmpty()) "" else "N"
+        val headers = mapOf(
+            "tr_id" to "TTTC2202R", // 거래 ID - 퇴직연금 펀드 잔고 조회
+            "tr_cont" to tc,
+        )
+        val queries = mapOf(
+            "CANO" to accountNum.take(8), // 종합계좌번호
+            "ACNT_PRDT_CD" to accountNum.drop(8), // 계좌상품코드 (IRP: 29)
+            "USER_DVSN_CD" to "00", // 사용자구분코드
+            "CTX_AREA_FK100" to fk100,
+            "CTX_AREA_NK100" to nk100,
+        )
+        accountService.getPensionFundAccount(headers, queries)
     }
 }

--- a/app/src/main/java/com/trueedu/project/repository/remote/AccountRemoteImpl.kt
+++ b/app/src/main/java/com/trueedu/project/repository/remote/AccountRemoteImpl.kt
@@ -38,4 +38,25 @@ class AccountRemoteImpl(
         )
         accountService.getAccount(headers, queries)
     }
+
+    override fun getPensionStocks(
+        accountNum: String,
+        fk100: String,
+        nk100: String,
+    ) = apiCallFlow {
+        val tc = if (fk100.isEmpty() || nk100.isEmpty()) "" else "N"
+        val headers = mapOf(
+            "tr_id" to "TTTC2208R", // 거래 ID - 퇴직연금 잔고 조회
+            "tr_cont" to tc,
+        )
+        val queries = mapOf(
+            "CANO" to accountNum.take(8), // 종합계좌번호
+            "ACNT_PRDT_CD" to accountNum.drop(8), // 계좌상품코드 (IRP: 29)
+            "ACCA_DVSN_CD" to "00", // 적립금구분코드
+            "INQR_DVSN" to "00", // 조회구분
+            "CTX_AREA_FK100" to fk100,
+            "CTX_AREA_NK100" to nk100,
+        )
+        accountService.getPensionAccount(headers, queries)
+    }
 }

--- a/app/src/main/java/com/trueedu/project/repository/remote/service/AccountService.kt
+++ b/app/src/main/java/com/trueedu/project/repository/remote/service/AccountService.kt
@@ -1,6 +1,7 @@
 package com.trueedu.project.repository.remote.service
 
 import com.trueedu.project.model.dto.account.AccountResponse
+import com.trueedu.project.model.dto.account.PensionAccountResponse
 import retrofit2.Response
 import retrofit2.http.GET
 import retrofit2.http.HeaderMap
@@ -12,4 +13,10 @@ interface AccountService {
         @HeaderMap headers: Map<String, String>,
         @QueryMap queries: Map<String, String>
     ): Response<AccountResponse>
+
+    @GET("uapi/domestic-stock/v1/trading/pension/inquire-balance")
+    suspend fun getPensionAccount(
+        @HeaderMap headers: Map<String, String>,
+        @QueryMap queries: Map<String, String>
+    ): Response<PensionAccountResponse>
 }

--- a/app/src/main/java/com/trueedu/project/repository/remote/service/AccountService.kt
+++ b/app/src/main/java/com/trueedu/project/repository/remote/service/AccountService.kt
@@ -2,6 +2,7 @@ package com.trueedu.project.repository.remote.service
 
 import com.trueedu.project.model.dto.account.AccountResponse
 import com.trueedu.project.model.dto.account.PensionAccountResponse
+import com.trueedu.project.model.dto.account.PensionFundResponse
 import retrofit2.Response
 import retrofit2.http.GET
 import retrofit2.http.HeaderMap
@@ -19,4 +20,10 @@ interface AccountService {
         @HeaderMap headers: Map<String, String>,
         @QueryMap queries: Map<String, String>
     ): Response<PensionAccountResponse>
+
+    @GET("uapi/domestic-stock/v1/trading/pension/inquire-balance")
+    suspend fun getPensionFundAccount(
+        @HeaderMap headers: Map<String, String>,
+        @QueryMap queries: Map<String, String>
+    ): Response<PensionFundResponse>
 }

--- a/app/src/main/java/com/trueedu/project/ui/views/home/HomeScreen.kt
+++ b/app/src/main/java/com/trueedu/project/ui/views/home/HomeScreen.kt
@@ -36,6 +36,7 @@ import com.trueedu.project.ui.views.StockDetailFragment
 import com.trueedu.project.ui.views.order.OrderFragment
 import com.trueedu.project.ui.views.search.StockSearchFragment
 import com.trueedu.project.ui.views.setting.AppKeyInputFragment
+import com.trueedu.project.utils.toAccountNumFormat
 
 @Composable
 fun HomeScreen(
@@ -91,6 +92,9 @@ fun HomeScreen(
             return@Scaffold
         }
 
+        val rawAccountNum = vm.accountNum.value.replace("-", "")
+        val isPension = vm.isPensionAccount(rawAccountNum)
+
         val state = rememberLazyListState()
         LazyColumn(
             state = state,
@@ -99,49 +103,36 @@ fun HomeScreen(
                 .fillMaxSize()
                 .padding(innerPadding)
         ) {
-            vm.userStocks.value?.output2?.firstOrNull()?.let {
-                item {
-                    AccountInfo(
-                        it,
-                        vm.marketPriceMode.value,
-                        onRefresh = {
-                            trueAnalytics.clickButton("home__refresh__click")
-                            vm.refresh {
-                                Toast.makeText(
-                                    context,
-                                    "자산 정보를 갱신했습니다.",
-                                    Toast.LENGTH_SHORT
-                                ).show()
-                            }
-                        },
-                        vm::onChangeMarketPriceMode
-                    )
-                }
-            } ?: item {
-                Margin(32)
-                EmptyHome()
-            }
+            if (isPension) {
+                // IRP 계좌
+                val pensionData = vm.pensionStocks.value
+                val pensionItems = pensionData?.output1
+                    ?.filter { it.holdingQuantity.toDouble() > 0 }
+                    ?: emptyList()
 
-            vm.userStocks.value?.output1?.let {
-                val items = it.filter { it.holdingQuantity.toDouble() > 0 }
-                // 광고
-                if (remoteConfig.adVisible.value && admobManager.nativeAd.value != null) {
-                    item { NativeAdView(admobManager.nativeAd.value!!) }
+                pensionData?.output2?.let { detail ->
+                    item {
+                        PensionAccountInfo(
+                            accountDetail = detail,
+                            items = pensionItems,
+                            onRefresh = {
+                                trueAnalytics.clickButton("home__refresh__click")
+                                vm.refreshPension(rawAccountNum) {
+                                    Toast.makeText(context, "자산 정보를 갱신했습니다.", Toast.LENGTH_SHORT).show()
+                                }
+                            }
+                        )
+                    }
+                } ?: item {
+                    Margin(32)
+                    EmptyHome()
                 }
-                itemsIndexed(items, { _, item -> item.code} ) { _, item ->
+
+                itemsIndexed(pensionItems, { _, item -> item.code }) { _, item ->
                     val stock = stockPool.get(item.code)
-                    HomeStockItem(
+                    PensionStockItem(
                         item = item,
                         stock = stock,
-                        marketPriceMode = vm.marketPriceMode.value,
-                        onPriceClick = { code ->
-                            trueAnalytics.clickButton("home__price__click")
-                            if (stockPool.get(code) == null) {
-                                Toast.makeText(context, "상장 폐지 종목입니다", Toast.LENGTH_SHORT).show()
-                                return@HomeStockItem
-                            }
-                            OrderFragment.show(code, fragmentManager)
-                        },
                         onItemClick = { code ->
                             stockPool.get(code)?.let { stockInfo ->
                                 trueAnalytics.clickButton("home__item__click")
@@ -149,6 +140,60 @@ fun HomeScreen(
                             }
                         },
                     )
+                }
+            } else {
+                // 일반 계좌
+                vm.userStocks.value?.output2?.firstOrNull()?.let {
+                    item {
+                        AccountInfo(
+                            it,
+                            vm.marketPriceMode.value,
+                            onRefresh = {
+                                trueAnalytics.clickButton("home__refresh__click")
+                                vm.refresh {
+                                    Toast.makeText(
+                                        context,
+                                        "자산 정보를 갱신했습니다.",
+                                        Toast.LENGTH_SHORT
+                                    ).show()
+                                }
+                            },
+                            vm::onChangeMarketPriceMode
+                        )
+                    }
+                } ?: item {
+                    Margin(32)
+                    EmptyHome()
+                }
+
+                vm.userStocks.value?.output1?.let {
+                    val items = it.filter { it.holdingQuantity.toDouble() > 0 }
+                    // 광고
+                    if (remoteConfig.adVisible.value && admobManager.nativeAd.value != null) {
+                        item { NativeAdView(admobManager.nativeAd.value!!) }
+                    }
+                    itemsIndexed(items, { _, item -> item.code }) { _, item ->
+                        val stock = stockPool.get(item.code)
+                        HomeStockItem(
+                            item = item,
+                            stock = stock,
+                            marketPriceMode = vm.marketPriceMode.value,
+                            onPriceClick = { code ->
+                                trueAnalytics.clickButton("home__price__click")
+                                if (stockPool.get(code) == null) {
+                                    Toast.makeText(context, "상장 폐지 종목입니다", Toast.LENGTH_SHORT).show()
+                                    return@HomeStockItem
+                                }
+                                OrderFragment.show(code, fragmentManager)
+                            },
+                            onItemClick = { code ->
+                                stockPool.get(code)?.let { stockInfo ->
+                                    trueAnalytics.clickButton("home__item__click")
+                                    StockDetailFragment.show(stockInfo, fragmentManager)
+                                }
+                            },
+                        )
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/trueedu/project/ui/views/home/HomeScreen.kt
+++ b/app/src/main/java/com/trueedu/project/ui/views/home/HomeScreen.kt
@@ -141,6 +141,14 @@ fun HomeScreen(
                         },
                     )
                 }
+
+                // 펀드 목록
+                val fundItems = vm.pensionFundStocks.value?.output1
+                    ?.filter { it.holdingQuantity.toDoubleOrNull()?.let { q -> q > 0 } == true }
+                    ?: emptyList()
+                itemsIndexed(fundItems, { _, item -> item.code }) { _, item ->
+                    PensionFundItem(item = item)
+                }
             } else {
                 // 일반 계좌
                 vm.userStocks.value?.output2?.firstOrNull()?.let {

--- a/app/src/main/java/com/trueedu/project/ui/views/home/HomeViews.kt
+++ b/app/src/main/java/com/trueedu/project/ui/views/home/HomeViews.kt
@@ -21,6 +21,7 @@ import com.trueedu.project.model.dto.account.AccountAsset
 import com.trueedu.project.model.dto.account.AccountDetail
 import com.trueedu.project.model.dto.account.PensionAsset
 import com.trueedu.project.model.dto.account.PensionDetail
+import com.trueedu.project.model.dto.account.PensionFundAsset
 import com.trueedu.project.model.dto.firebase.StockInfo
 import com.trueedu.project.ui.common.Margin
 import com.trueedu.project.ui.common.TouchIconWithSizeRotating
@@ -354,6 +355,57 @@ fun PensionStockItem(
             val profit = item.profitLossAmount.toDouble()
             val profitRate = try {
                 item.evaluationEarningsRate.toDouble()
+            } catch (_: NumberFormatException) {
+                0.0
+            }
+            TrueText(
+                s = formatter.format(evalAmount),
+                fontSize = 14,
+                fontWeight = FontWeight.W600,
+                color = MaterialTheme.colorScheme.primary,
+            )
+            TrueText(
+                s = "${formatter.format(profit, true)} (${rateFormatter.format(profitRate, true)})",
+                fontSize = 12,
+                color = ChartColor.color(profit),
+            )
+        }
+    }
+}
+
+@Composable
+fun PensionFundItem(
+    item: PensionFundAsset,
+) {
+    val formatter = CashFormatter()
+    val rateFormatter = RateFormatter()
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween,
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(8.dp)
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            TrueText(
+                s = item.nameKr,
+                fontSize = 14,
+                color = MaterialTheme.colorScheme.primary,
+                maxLines = 1,
+            )
+            val priceString = intFormatter.format(item.purchaseAveragePrice.toDouble())
+            TrueText(
+                s = "${priceString}원 • ${item.holdingQuantity}좌",
+                fontSize = 13,
+                color = MaterialTheme.colorScheme.secondary,
+            )
+        }
+
+        Column(horizontalAlignment = Alignment.End) {
+            val evalAmount = item.evaluationAmount.toDouble()
+            val profit = item.profitLossAmount.toDouble()
+            val profitRate = try {
+                item.profitLossRate.toDouble()
             } catch (_: NumberFormatException) {
                 0.0
             }

--- a/app/src/main/java/com/trueedu/project/ui/views/home/HomeViews.kt
+++ b/app/src/main/java/com/trueedu/project/ui/views/home/HomeViews.kt
@@ -19,6 +19,8 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.trueedu.project.model.dto.account.AccountAsset
 import com.trueedu.project.model.dto.account.AccountDetail
+import com.trueedu.project.model.dto.account.PensionAsset
+import com.trueedu.project.model.dto.account.PensionDetail
 import com.trueedu.project.model.dto.firebase.StockInfo
 import com.trueedu.project.ui.common.Margin
 import com.trueedu.project.ui.common.TouchIconWithSizeRotating
@@ -239,6 +241,130 @@ fun HomeStockItem(
             )
             TrueText(
                 s = "$profitString ($profitRateString)",
+                fontSize = 12,
+                color = ChartColor.color(profit),
+            )
+        }
+    }
+}
+
+@Composable
+fun PensionAccountInfo(
+    accountDetail: PensionDetail,
+    items: List<PensionAsset>,
+    onRefresh: () -> Unit,
+) {
+    val formatter = CashFormatter()
+    val rateFormatter = RateFormatter()
+    val total = accountDetail.totalEvaluationAmount.toDouble()
+    val totalString = formatter.format(total)
+
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween,
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 8.dp)
+            .padding(bottom = 8.dp)
+    ) {
+        val profit = accountDetail.totalProfitAmount(items)
+        val profitString = formatter.format(profit, true)
+        val rate = accountDetail.totalProfitRate(items)
+        val profitRateString = rateFormatter.format(rate, true)
+
+        Column {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                TrueText(
+                    s = totalString,
+                    fontSize = 24,
+                    fontWeight = FontWeight.W500,
+                    color = MaterialTheme.colorScheme.primary
+                )
+                TouchIconWithSizeRotating(
+                    size = 24.dp,
+                    tint = MaterialTheme.colorScheme.primary,
+                    icon = Icons.Outlined.Sync,
+                    onClick = onRefresh
+                )
+            }
+            TrueText(
+                s = "$profitString ($profitRateString)",
+                fontSize = 14,
+                color = ChartColor.color(profit)
+            )
+        }
+    }
+
+    Row(modifier = Modifier.padding(horizontal = 16.dp)) {
+        HeaderTitle("예수금")
+        HeaderTitle("D+1 예수금")
+        HeaderTitle("D+2 예수금")
+    }
+    Row(modifier = Modifier.padding(horizontal = 16.dp)) {
+        BodyTitle(formatter.format(accountDetail.depositAccountTotalAmount.toDouble()))
+        BodyTitle(formatter.format(accountDetail.nextDayExcessAmount.toDouble()))
+        BodyTitle(formatter.format(accountDetail.previousRedemptionExcessAmount.toDouble()))
+    }
+    Margin(8)
+}
+
+@Composable
+fun PensionStockItem(
+    item: PensionAsset,
+    stock: StockInfo?,
+    onItemClick: (String) -> Unit,
+) {
+    val formatter = CashFormatter()
+    val rateFormatter = RateFormatter()
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween,
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { onItemClick(item.code) }
+            .padding(8.dp)
+    ) {
+        Column {
+            Row {
+                TrueText(
+                    s = item.nameKr,
+                    fontSize = 14,
+                    color = MaterialTheme.colorScheme.primary,
+                    maxLines = 1,
+                )
+                if (stock?.halt() == true) {
+                    Margin(2)
+                    HaltBadge()
+                }
+                if (stock?.designated() == true) {
+                    Margin(2)
+                    DesignatedBadge()
+                }
+            }
+            val priceString = intFormatter.format(item.purchaseAveragePrice.toDouble())
+            TrueText(
+                s = "${priceString}원 • ${item.holdingQuantity}주",
+                fontSize = 13,
+                color = MaterialTheme.colorScheme.secondary,
+            )
+        }
+
+        Column(horizontalAlignment = Alignment.End) {
+            val evalAmount = item.evaluationAmount.toDouble()
+            val profit = item.profitLossAmount.toDouble()
+            val profitRate = try {
+                item.evaluationEarningsRate.toDouble()
+            } catch (_: NumberFormatException) {
+                0.0
+            }
+            TrueText(
+                s = formatter.format(evalAmount),
+                fontSize = 14,
+                fontWeight = FontWeight.W600,
+                color = MaterialTheme.colorScheme.primary,
+            )
+            TrueText(
+                s = "${formatter.format(profit, true)} (${rateFormatter.format(profitRate, true)})",
                 fontSize = 12,
                 color = ChartColor.color(profit),
             )


### PR DESCRIPTION
## 개요
IRP(개인형퇴직연금) 계좌를 홈 화면에서 조회할 수 있도록 지원합니다.

## 변경 사항

### DTO
- `PensionAccountResponse` 추가 — ETF/주식 잔고 (TTTC2208R)
- `PensionFundResponse` 추가 — 펀드 포함 운용 성과 (TTTC2202R)

### Remote
- `AccountService`: `getPensionAccount`, `getPensionFundAccount` 엔드포인트 추가
- `AccountRemote`: `getPensionStocks`, `getPensionFundStocks` 인터페이스 추가
- `AccountRemoteImpl`: 두 API 구현

### Data
- `UserAssets`: `pensionAssets`, `pensionFundAssets` Flow 추가
- 계좌번호 끝 2자리로 IRP 자동 판별 (`isPensionAccount`)
- IRP 계좌 선택 시 두 API 동시 호출

### ViewModel / UI
- `MainViewModel`: `pensionStocks`, `pensionFundStocks` 상태, `refreshPension`, `isPensionAccount` 추가
- `HomeViews`: `PensionAccountInfo`, `PensionStockItem`, `PensionFundItem` Composable 추가
- `HomeScreen`: IRP/일반 계좌 자동 분기 렌더링

## 동작
- 계좌번호 끝 2자리 `29` → IRP 자동 인식
- IRP 홈: 총자산 · 손익 · 예수금 + ETF/주식 종목 목록 + 펀드 목록 표시
- 새로고침 시 두 API 동시 갱신

## 제한 사항
- KIS 오픈API는 IRP 내 펀드(수익증권) 데이터를 반환하지 않음 (TTTC2208R, TTTC2202R 모두 동일)
- 펀드 데이터는 HTS/MTS에서만 확인 가능