### PR TITLE
내 주문 체결 통보(H0STCNI0)만 notification으로 표시

### DIFF
--- a/app/src/main/java/com/trueedu/project/data/realtime/WsMessageHandler.kt
+++ b/app/src/main/java/com/trueedu/project/data/realtime/WsMessageHandler.kt
@@ -8,8 +8,10 @@ import com.trueedu.project.data.log.logE
 import com.trueedu.project.model.event.WebSocketKeyIssued
 import com.trueedu.project.model.ws.RealTimeOrder
 import com.trueedu.project.model.ws.RealTimeTrade
+import com.trueedu.project.model.ws.TradeNotification
 import com.trueedu.project.model.ws.TransactionId
 import com.trueedu.project.model.ws.WsResponse
+import com.trueedu.project.utils.decryptAes
 import com.trueedu.project.repository.local.Local
 import com.trueedu.project.repository.remote.service.WebSocketService
 import kotlinx.coroutines.CoroutineScope
@@ -40,10 +42,16 @@ class WsMessageHandler @Inject constructor(
     private var foreground = false
     private var stopAt = 0L // background 로 진입한 시각
 
-    // 거래 데이터
+    // 거래 데이터 (시세 체결 - 구독 종목 전체)
     val tradeSignal = MutableSharedFlow<RealTimeTrade>()
     // 호가 데이터
     val quotesSignal = MutableSharedFlow<RealTimeOrder>()
+    // 내 주문 체결 통보 (H0STCNI0)
+    val orderExecutionSignal = MutableSharedFlow<TradeNotification>()
+
+    // 체결통보 AES 복호화 키/IV (구독 응답에서 수신)
+    private var tradeNotificationKey: String? = null
+    private var tradeNotificationIv: String? = null
 
     init {
         MainScope().launch {
@@ -107,7 +115,9 @@ class WsMessageHandler @Inject constructor(
             override fun onMessage(webSocket: WebSocket, text: String) {
                 super.onMessage(webSocket, text)
                 logD("onMessage: $text")
-                if (text[0] == '0' || text[0] == '1') { // 실시간체결 or 실시간호가
+                if (text[0] == '1') { // 암호화된 실시간 데이터 (체결통보)
+                    handleEncryptedRealTimeResponse(text)
+                } else if (text[0] == '0') { // 비암호화 실시간 데이터 (시세체결, 호가)
                     handleRealTimeResponse(text)
                 } else { // system message or PINGPONG
                     val res = WsResponse.from(text)
@@ -123,8 +133,16 @@ class WsMessageHandler @Inject constructor(
                                 event.emit(res)
                             }
                         }
-                        TransactionId.TradeNotification -> {
-                            // TODO
+                        TransactionId.TradeNotification,
+                        TransactionId.TradeNotificationTest -> {
+                            // 체결통보 구독 응답: AES key/iv 저장
+                            val iv = res.body?.output?.iv
+                            val key = res.body?.output?.key
+                            if (!iv.isNullOrEmpty() && !key.isNullOrEmpty()) {
+                                tradeNotificationIv = iv
+                                tradeNotificationKey = key
+                                logD("TradeNotification AES key/iv saved")
+                            }
                         }
                     }
                 }
@@ -145,6 +163,44 @@ class WsMessageHandler @Inject constructor(
                 }
             }
         })
+    }
+
+    /**
+     * 암호화된 실시간 데이터 처리 (첫 번째 문자가 '1')
+     * 현재는 체결통보(H0STCNI0)만 암호화됨
+     */
+    private fun handleEncryptedRealTimeResponse(text: String) {
+        val org = text.split("|")
+        val transactionId = TransactionId.entries.firstOrNull { it.value == org[1] }
+        val encryptedData = org[3]
+
+        when (transactionId) {
+            TransactionId.TradeNotification,
+            TransactionId.TradeNotificationTest -> {
+                val key = tradeNotificationKey
+                val iv = tradeNotificationIv
+                if (key.isNullOrEmpty() || iv.isNullOrEmpty()) {
+                    logE("TradeNotification AES key/iv not ready, skipping")
+                    return
+                }
+                val decrypted = decryptAes(encryptedData, key, iv)
+                if (decrypted.isEmpty()) {
+                    logE("TradeNotification AES decryption failed")
+                    return
+                }
+                val notification = TradeNotification.from(decrypted)
+                // pValue[13] == "2" 인 경우만 실제 체결 통보
+                if (TradeNotification.isExecution(notification.data)) {
+                    logD("OrderExecution: ${notification.code} ${notification.execQty}주 @${notification.execPrice}")
+                    MainScope().launch {
+                        orderExecutionSignal.emit(notification)
+                    }
+                }
+            }
+            else -> {
+                logD("Unknown encrypted transactionId: ${org[1]}")
+            }
+        }
     }
 
     private fun handleRealTimeResponse(text: String) {

--- a/app/src/main/java/com/trueedu/project/model/ws/TradeNotification.kt
+++ b/app/src/main/java/com/trueedu/project/model/ws/TradeNotification.kt
@@ -1,0 +1,60 @@
+package com.trueedu.project.model.ws
+
+/**
+ * 국내주식 실시간 체결통보 (H0STCNI0)
+ *
+ * 데이터는 AES256 암호화되어 수신되며, 복호화 후 '^'로 파싱한다.
+ *
+ * 필드 순서 (체결통보, pValue[13] == '2' 인 경우):
+ * [0]  고객ID
+ * [1]  계좌번호
+ * [2]  주문번호
+ * [3]  원주문번호
+ * [4]  매도매수구분 (01: 매도, 02: 매수)
+ * [5]  정정구분
+ * [6]  주문종류
+ * [7]  주문조건
+ * [8]  주식단축종목코드
+ * [9]  체결수량
+ * [10] 체결단가
+ * [11] 주식체결시간 (HHmmss)
+ * [12] 거부여부 (0: 정상, 1: 거부)
+ * [13] 체결여부 (1: 주문·정정·취소·거부, 2: 체결)
+ * [14] 접수여부
+ * [25] 주문가격
+ */
+class TradeNotification(
+    val data: List<String>
+) {
+    companion object {
+        fun from(rawData: String): TradeNotification {
+            return TradeNotification(data = rawData.split("^"))
+        }
+
+        /** pValue[13] == "2" 이면 체결, 그 외는 주문/정정/취소/거부 접수 통보 */
+        fun isExecution(data: List<String>): Boolean {
+            return data.getOrNull(13) == "2"
+        }
+    }
+
+    // 고객 ID (HTS ID)
+    val customerId = data.getOrNull(0).orEmpty()
+    // 계좌번호
+    val accountNum = data.getOrNull(1).orEmpty()
+    // 주문번호
+    val orderNum = data.getOrNull(2).orEmpty()
+    // 매도매수구분: 01-매도, 02-매수
+    val buySellType = data.getOrNull(4).orEmpty()
+    // 주식단축종목코드
+    val code = data.getOrNull(8).orEmpty()
+    // 체결수량
+    val execQty = data.getOrNull(9)?.toDoubleOrNull() ?: 0.0
+    // 체결단가
+    val execPrice = data.getOrNull(10)?.toDoubleOrNull() ?: 0.0
+    // 주식체결시간 (HHmmss)
+    val execTime = data.getOrNull(11).orEmpty()
+    // 체결여부: 2 = 체결
+    val execYn = data.getOrNull(13).orEmpty()
+
+    val isBuy: Boolean get() = buySellType == "02"
+}

--- a/app/src/main/java/com/trueedu/project/model/ws/TransactionId.kt
+++ b/app/src/main/java/com/trueedu/project/model/ws/TransactionId.kt
@@ -16,5 +16,7 @@ enum class TransactionId(val value: String) {
     @SerialName("H0NXCNT0")
     RealTimeTradeNxt("H0NXCNT0"), // 실시간 체결 (NXT)
     @SerialName("H0STCNI0")
-    TradeNotification("H0STCNI0"), // 체결 통보
+    TradeNotification("H0STCNI0"), // 체결 통보 (실전)
+    @SerialName("H0STCNI9")
+    TradeNotificationTest("H0STCNI9"), // 체결 통보 (모의)
 }

--- a/app/src/main/java/com/trueedu/project/notification/TradeNotificationManager.kt
+++ b/app/src/main/java/com/trueedu/project/notification/TradeNotificationManager.kt
@@ -11,6 +11,7 @@ import androidx.core.app.NotificationManagerCompat
 import com.trueedu.project.MainActivity
 import com.trueedu.project.R
 import com.trueedu.project.model.ws.RealTimeTrade
+import com.trueedu.project.model.ws.TradeNotification
 import dagger.hilt.android.qualifiers.ApplicationContext
 import java.util.concurrent.atomic.AtomicInteger
 import javax.inject.Inject
@@ -44,7 +45,48 @@ class TradeNotificationManager @Inject constructor(
     }
 
     /**
-     * 실시간 체결 이벤트를 notification으로 표시
+     * 내 주문 체결 통보(H0STCNI0)를 notification으로 표시
+     */
+    fun showOrderExecutionNotification(notification: TradeNotification, stockName: String? = null) {
+        val notificationManager = NotificationManagerCompat.from(context)
+        if (!notificationManager.areNotificationsEnabled()) return
+
+        val displayName = if (!stockName.isNullOrEmpty()) stockName else notification.code
+        val buySell = if (notification.isBuy) "매수" else "매도"
+        val title = "[$buySell 체결] $displayName"
+        val body = buildString {
+            append("${formatQty(notification.execQty)}주")
+            append(" @")
+            append(formatPrice(notification.execPrice))
+            append("  |  ")
+            append(formatTime(notification.execTime))
+        }
+
+        val intent = Intent(context, MainActivity::class.java).apply {
+            flags = Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP
+            putExtra("code", notification.code)
+        }
+        val pendingIntent = PendingIntent.getActivity(
+            context,
+            notification.code.hashCode(),
+            intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+        )
+
+        val notif = NotificationCompat.Builder(context, CHANNEL_ID)
+            .setSmallIcon(R.drawable.ic_notification_trade)
+            .setContentTitle(title)
+            .setContentText(body)
+            .setAutoCancel(true)
+            .setPriority(NotificationCompat.PRIORITY_HIGH)
+            .setContentIntent(pendingIntent)
+            .build()
+
+        notificationManager.notify(notificationIdCounter.getAndIncrement(), notif)
+    }
+
+    /**
+     * 실시간 체결 이벤트를 notification으로 표시 (시세 체결용 - 현재 미사용)
      */
     fun showTradeNotification(trade: RealTimeTrade, stockName: String? = null) {
         val notificationManager = NotificationManagerCompat.from(context)
@@ -86,6 +128,10 @@ class TradeNotificationManager @Inject constructor(
 
     private fun formatPrice(price: Double): String {
         return "%,.0f원".format(price)
+    }
+
+    private fun formatQty(qty: Double): String {
+        return "%,.0f".format(qty)
     }
 
     private fun formatRate(rate: Double): String {

--- a/app/src/main/java/com/trueedu/project/notification/TradeNotificationWorker.kt
+++ b/app/src/main/java/com/trueedu/project/notification/TradeNotificationWorker.kt
@@ -2,24 +2,35 @@ package com.trueedu.project.notification
 
 import android.util.Log
 import com.trueedu.project.data.StockPool
+import com.trueedu.project.data.TokenKeyManager
 import com.trueedu.project.data.realtime.WsMessageHandler
+import com.trueedu.project.model.ws.TransactionId
+import com.trueedu.project.model.ws.WsRequest
+import com.trueedu.project.model.ws.WsRequestBody
+import com.trueedu.project.model.ws.WsRequestBodyInput
+import com.trueedu.project.model.ws.WsRequestHeader
+import com.trueedu.project.repository.local.Local
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
 import javax.inject.Inject
 import javax.inject.Singleton
 
 /**
- * WsMessageHandler의 tradeSignal을 구독하여
- * 실시간 체결 이벤트를 notification으로 표시하는 컴포넌트
+ * WsMessageHandler의 orderExecutionSignal을 구독하여
+ * 내 주문 체결 이벤트(H0STCNI0)를 notification으로 표시하는 컴포넌트
  */
 @Singleton
 class TradeNotificationWorker @Inject constructor(
     private val wsMessageHandler: WsMessageHandler,
     private val stockPool: StockPool,
     private val tradeNotificationManager: TradeNotificationManager,
+    private val tokenKeyManager: TokenKeyManager,
+    private val local: Local,
 ) {
     companion object {
         private val TAG = TradeNotificationWorker::class.java.simpleName
@@ -32,18 +43,54 @@ class TradeNotificationWorker @Inject constructor(
         if (job?.isActive == true) return
         Log.d(TAG, "start()")
 
+        subscribeTradeNotification()
+
         job = scope.launch {
-            wsMessageHandler.tradeSignal.collect { trade ->
-                Log.d(TAG, "trade received: ${trade.code} ${trade.price}")
-                val stockName = stockPool.get(trade.code)?.nameKr
-                tradeNotificationManager.showTradeNotification(trade, stockName)
+            wsMessageHandler.orderExecutionSignal.collect { notification ->
+                Log.d(TAG, "order execution received: ${notification.code} ${notification.execQty}주 @${notification.execPrice}")
+                val stockName = stockPool.get(notification.code)?.nameKr
+                tradeNotificationManager.showOrderExecutionNotification(notification, stockName)
             }
         }
     }
 
     fun stop() {
         Log.d(TAG, "stop()")
+        unsubscribeTradeNotification()
         job?.cancel()
         job = null
+    }
+
+    /** H0STCNI0 체결통보 구독 요청 (tr_key = HTS ID) */
+    private fun subscribeTradeNotification() {
+        val htsId = tokenKeyManager.userKey.value?.htsId
+        if (htsId.isNullOrEmpty()) {
+            Log.w(TAG, "htsId is null or empty, skip H0STCNI0 subscription")
+            return
+        }
+        wsMessageHandler.send(makeTradeNotificationRequest(htsId, subscribe = true))
+        Log.d(TAG, "H0STCNI0 subscribed for htsId=$htsId")
+    }
+
+    /** H0STCNI0 체결통보 구독 해제 */
+    private fun unsubscribeTradeNotification() {
+        val htsId = tokenKeyManager.userKey.value?.htsId ?: return
+        wsMessageHandler.send(makeTradeNotificationRequest(htsId, subscribe = false))
+        Log.d(TAG, "H0STCNI0 unsubscribed for htsId=$htsId")
+    }
+
+    private fun makeTradeNotificationRequest(htsId: String, subscribe: Boolean): String {
+        val header = WsRequestHeader(
+            approvalKey = local.webSocketKey,
+            customerType = "P",
+            transactionType = if (subscribe) "1" else "2",
+            contentType = "utf-8",
+        )
+        val input = WsRequestBodyInput(
+            transactionId = TransactionId.TradeNotification,
+            transactionKey = htsId,
+        )
+        val body = WsRequestBody(input)
+        return Json.encodeToString(WsRequest(header, body))
     }
 }


### PR DESCRIPTION
## 문제
TradeNotificationWorker가 `tradeSignal`(H0STCNT0 실시간시세체결)을 구독하고 있어, **시장의 모든 종목 체결**마다 notification이 발생하고 있었음.

체결통보(`H0STCNI0`)는 WsMessageHandler에 `// TODO`로만 남아있었음.

## 수정 내용

### 신규
- `TradeNotification.kt` — H0STCNI0 체결통보 데이터 모델

### WsMessageHandler
- `orderExecutionSignal` 추가
- 암호화 데이터 처리 분리 (`handleEncryptedRealTimeResponse`)
- H0STCNI0 구독 응답에서 AES key/iv 저장 후 복호화
- 체결여부[13] == '2' 인 경우만 emit

### TradeNotificationWorker
- `tradeSignal` 대신 `orderExecutionSignal` 구독으로 변경
- 시작 시 htsId로 H0STCNI0 구독, 종료 시 해제

### TradeNotificationManager
- `showOrderExecutionNotification()` 추가 (매수/매도, 체결수량, 체결단가 표시)