### PR TITLE
토큰 만료(EGW00123) 시 자동 갱신 및 재시도 인터셉터 추가

### DIFF
--- a/app/src/main/java/com/trueedu/project/di/NetworkModule.kt
+++ b/app/src/main/java/com/trueedu/project/di/NetworkModule.kt
@@ -11,6 +11,7 @@ import com.orhanobut.logger.Logger
 import com.trueedu.project.BuildConfig
 import com.trueedu.project.network.TokenAuthenticator
 import com.trueedu.project.network.TokenInterceptor
+import com.trueedu.project.network.TokenRefreshInterceptor
 import com.trueedu.project.network.addHttpLoggingInterceptor
 import com.trueedu.project.repository.local.Local
 import com.trueedu.project.repository.remote.service.AuthService
@@ -113,6 +114,8 @@ object NetworkModule {
         loggingInterceptor: HttpLoggingInterceptor,
         chuckerInterceptor: ChuckerInterceptor,
         tokenInterceptor: TokenInterceptor,
+        tokenRefreshInterceptor: TokenRefreshInterceptor,
+        tokenAuthenticator: TokenAuthenticator,
         flipperOkhttpInterceptor: FlipperOkhttpInterceptor
     ): OkHttpClient {
         return OkHttpClient.Builder()
@@ -121,7 +124,9 @@ object NetworkModule {
                     addHttpLoggingInterceptor()
                 }
             }
-            .addInterceptor(tokenInterceptor)
+            .addInterceptor(tokenInterceptor)         // 요청에 토큰 헤더 삽입
+            .addInterceptor(tokenRefreshInterceptor)  // 응답 body에서 토큰 만료 감지 → 갱신 + 재시도
+            .authenticator(tokenAuthenticator)        // 혹시 401이 오는 경우 대비
             .addInterceptor(loggingInterceptor)
             .addInterceptor(chuckerInterceptor)
             .addNetworkInterceptor(flipperOkhttpInterceptor)

--- a/app/src/main/java/com/trueedu/project/network/TokenRefreshInterceptor.kt
+++ b/app/src/main/java/com/trueedu/project/network/TokenRefreshInterceptor.kt
@@ -1,0 +1,86 @@
+package com.trueedu.project.network
+
+import com.trueedu.project.di.TokenRefreshService
+import com.trueedu.project.model.dto.auth.TokenRequest
+import com.trueedu.project.repository.local.Local
+import com.trueedu.project.repository.remote.service.AuthService
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import okhttp3.Interceptor
+import okhttp3.Response
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * KIS API는 토큰 만료 시 HTTP 200/500 + body { "rt_cd": "1", "msg_cd": "EGW00123" }을 반환.
+ * OkHttp Authenticator(401 전용)로는 감지 불가하므로, 응답 body를 검사해 갱신 후 재시도한다.
+ *
+ * 동시성: @Synchronized로 중복 갱신 방지 (여러 요청이 동시에 만료 감지해도 한 번만 갱신).
+ */
+@Singleton
+class TokenRefreshInterceptor @Inject constructor(
+    @TokenRefreshService private val authService: AuthService,
+    private val local: Local,
+) : Interceptor {
+
+    companion object {
+        private const val EXPIRED_MSG_CD = "EGW00123"
+    }
+
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val response = chain.proceed(chain.request())
+
+        // 토큰 만료 코드 감지 (body를 소비하지 않도록 peekBody 사용)
+        if (!isTokenExpired(response)) return response
+
+        response.close()
+
+        // 토큰 갱신 (동기, 동시 갱신 방지)
+        val refreshed = refreshTokenSync() ?: return chain.proceed(chain.request())
+
+        // 새 토큰으로 헤더 교체 후 재시도
+        val newRequest = chain.request().newBuilder()
+            .header("authorization", "Bearer $refreshed")
+            .build()
+        return chain.proceed(newRequest)
+    }
+
+    private fun isTokenExpired(response: Response): Boolean {
+        return try {
+            val body = response.peekBody(4096).string()
+            val json = Json { ignoreUnknownKeys = true }
+            val obj = json.parseToJsonElement(body).jsonObject
+            val msgCd = obj["msg_cd"]?.jsonPrimitive?.content
+            msgCd == EXPIRED_MSG_CD
+        } catch (e: Exception) {
+            false
+        }
+    }
+
+    @Synchronized
+    private fun refreshTokenSync(): String? {
+        // 다른 스레드가 이미 갱신했을 수 있으므로 현재 토큰이 바뀌었는지 확인
+        val currentToken = local.accessToken
+
+        return runBlocking {
+            val userKey = local.getUserKeys().lastOrNull() ?: return@runBlocking null
+            val request = TokenRequest(
+                grantType = "client_credentials",
+                appKey = userKey.appKey,
+                appSecret = userKey.appSecret,
+            )
+            val result = runCatching { authService.refreshToken(request) }.getOrNull()
+                ?: return@runBlocking null
+
+            if (result.isSuccessful) {
+                val tokenResponse = result.body() ?: return@runBlocking null
+                local.setAccessToken(tokenResponse)
+                tokenResponse.accessToken
+            } else {
+                null
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 문제

KIS API는 토큰이 만료됐을 때 HTTP 500 + 다음 응답을 반환합니다:
```json
{"rt_cd":"1","msg_cd":"EGW00123","msg1":"기간이 만료된 token 입니다."}
```

OkHttp의 `Authenticator`는 HTTP 401에만 동작하므로 이 케이스를 감지하지 못해 토큰 갱신이 이루어지지 않았습니다.

## 변경 사항

### `TokenRefreshInterceptor` 신규 추가
- 응답 body를 `peekBody()`로 소비 없이 읽어 `msg_cd == "EGW00123"` 감지
- 감지 시 토큰 갱신 후 원래 요청을 새 토큰으로 재시도
- `@Synchronized`로 다수 요청이 동시에 만료 감지해도 갱신은 한 번만 실행

### `NetworkModule` 수정
- `tokenRefreshInterceptor` 등록 (`tokenInterceptor` 바로 뒤)
- `tokenAuthenticator`도 `.authenticator()`에 등록 (기존에 누락되어 있었음)