### PR TITLE
모든 종목 주문 거래소 KRX 고정

### DIFF
--- a/app/src/main/java/com/trueedu/project/repository/remote/OrderRemoteImpl.kt
+++ b/app/src/main/java/com/trueedu/project/repository/remote/OrderRemoteImpl.kt
@@ -89,10 +89,9 @@ class OrderRemoteImpl(
             "ORD_DVSN" to "00", // 주문 구분 - 일단 지정가로 주문하기
             "ORD_QTY" to quantity, // 주문 수량
             "ORD_UNPR" to price, // 주문 단가
-            "EXCG_ID_DVSN_CD" to if (isSpac) "KRX" else "SOR", // 한국거래소 : KRX (기본값)
+            "EXCG_ID_DVSN_CD" to "KRX", // 한국거래소 고정 (NXT 지원 여부 파악 전까지)
                                         // 대체거래소 (넥스트레이드) : NXT
                                         // SOR (Smart Order Routing) : SOR
-                                        // 스팩은 KRX 거래소에만 상장되므로 KRX 고정
         )
         orderService.buy(headers, body)
     }


### PR DESCRIPTION
## 변경 내용

- `EXCG_ID_DVSN_CD` 파라미터를 스팩/일반 구분 없이 항상 `KRX`로 고정
- 기존 `SOR` 사용 시 "해당 종목 정보가 없습니다. NXT 상장 종목인지 확인하세요" 오류 발생

## 배경

NXT(넥스트레이드) 지원 여부를 마스터 파일로 구분하기 어려운 상황이라, NXT 지원 여부 파악 전까지 KRX 고정 처리.

## TODO

- NXT 전용 마스터 파일 또는 API가 확인되면 종목별 거래소 자동 선택 로직 추가