### PR TITLE
코스피/코스닥 지수 REST API 및 웹소켓 실시간 구독 추가

### DIFF
--- a/app/src/main/java/com/trueedu/project/data/realtime/MarketIndexManager.kt
+++ b/app/src/main/java/com/trueedu/project/data/realtime/MarketIndexManager.kt
@@ -1,0 +1,104 @@
+package com.trueedu.project.data.realtime
+
+import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.runtime.snapshotFlow
+import com.trueedu.project.data.log.logD
+import com.trueedu.project.model.ws.RealTimeIndex
+import com.trueedu.project.model.ws.TransactionId
+import com.trueedu.project.model.ws.WsRequest
+import com.trueedu.project.model.ws.WsRequestBody
+import com.trueedu.project.model.ws.WsRequestBodyInput
+import com.trueedu.project.model.ws.WsRequestHeader
+import com.trueedu.project.repository.local.Local
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * 실시간 업종지수(코스피/코스닥) 웹소켓 구독 관리
+ */
+@Singleton
+class MarketIndexManager @Inject constructor(
+    private val local: Local,
+    private val wsMessageHandler: WsMessageHandler,
+) {
+    companion object {
+        private val INDEX_CODES = listOf("0001", "1001") // 코스피, 코스닥
+    }
+
+    private var job: Job? = null
+
+    // key: "0001"(코스피) / "1001"(코스닥)
+    val dataMap = mutableStateMapOf<String, RealTimeIndex>()
+
+    fun start() {
+        job = MainScope().launch(Dispatchers.IO) {
+            launch {
+                snapshotFlow { wsMessageHandler.on.value }
+                    .collect {
+                        if (it) {
+                            subscribe()
+                        }
+                    }
+            }
+            launch {
+                wsMessageHandler.indexSignal
+                    .collect {
+                        dataMap[it.code] = it
+                    }
+            }
+        }
+
+        MainScope().launch(Dispatchers.IO) {
+            subscribe()
+        }
+    }
+
+    fun stop() {
+        MainScope().launch(Dispatchers.IO) {
+            unsubscribe()
+
+            job?.cancel()
+            job = null
+        }
+    }
+
+    private suspend fun subscribe() {
+        logD("MarketIndexManager subscribe")
+        INDEX_CODES.forEach {
+            wsMessageHandler.send(makeRequest(it, true))
+            delay(10)
+        }
+    }
+
+    private suspend fun unsubscribe() {
+        logD("MarketIndexManager unsubscribe")
+        INDEX_CODES.forEach {
+            wsMessageHandler.send(makeRequest(it, false))
+            delay(10)
+        }
+    }
+
+    private fun makeRequest(code: String, subscribe: Boolean): String {
+        val transactionType = if (subscribe) "1" else "2"
+
+        val header = WsRequestHeader(
+            approvalKey = local.webSocketKey,
+            customerType = "P",
+            transactionType = transactionType,
+            contentType = "utf-8",
+        )
+        val input = WsRequestBodyInput(
+            transactionId = TransactionId.RealTimeIndex,
+            transactionKey = code,
+        )
+        val body = WsRequestBody(input)
+        return Json.encodeToString(WsRequest(header, body))
+    }
+}

--- a/app/src/main/java/com/trueedu/project/data/realtime/WsMessageHandler.kt
+++ b/app/src/main/java/com/trueedu/project/data/realtime/WsMessageHandler.kt
@@ -6,6 +6,7 @@ import com.trueedu.project.data.TokenKeyManager
 import com.trueedu.project.data.log.logD
 import com.trueedu.project.data.log.logE
 import com.trueedu.project.model.event.WebSocketKeyIssued
+import com.trueedu.project.model.ws.RealTimeIndex
 import com.trueedu.project.model.ws.RealTimeOrder
 import com.trueedu.project.model.ws.RealTimeTrade
 import com.trueedu.project.model.ws.TradeNotification
@@ -48,6 +49,8 @@ class WsMessageHandler @Inject constructor(
     val quotesSignal = MutableSharedFlow<RealTimeOrder>()
     // 내 주문 체결 통보 (H0STCNI0)
     val orderExecutionSignal = MutableSharedFlow<TradeNotification>()
+    // 실시간 업종지수 (H0UPCNT0)
+    val indexSignal = MutableSharedFlow<RealTimeIndex>()
 
     // 체결통보 AES 복호화 키/IV (구독 응답에서 수신)
     private var tradeNotificationKey: String? = null
@@ -236,6 +239,12 @@ class WsMessageHandler @Inject constructor(
                 val dto = RealTimeTrade.from(data)
                 MainScope().launch {
                     tradeSignal.emit(dto)
+                }
+            }
+            TransactionId.RealTimeIndex -> {
+                val dto = RealTimeIndex.from(data)
+                MainScope().launch {
+                    indexSignal.emit(dto)
                 }
             }
             else -> {

--- a/app/src/main/java/com/trueedu/project/model/dto/price/IndexResponse.kt
+++ b/app/src/main/java/com/trueedu/project/model/dto/price/IndexResponse.kt
@@ -1,0 +1,34 @@
+package com.trueedu.project.model.dto.price
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class IndexResponse(
+    val output: IndexDetail?,
+    @SerialName("rt_cd")
+    val rtCd: String,
+    @SerialName("msg_cd")
+    val msgCd: String,
+    val msg1: String,
+)
+
+@Serializable
+data class IndexDetail(
+    @SerialName("bstp_nmix_prpr")
+    val price: String, // 업종 현재지수
+    @SerialName("bstp_nmix_prdy_vrss")
+    val priceChange: String, // 전일 대비
+    @SerialName("prdy_vrss_sign")
+    val priceChangeSign: String, // 전일 대비 부호 1:상한 2:상승 3:보합 4:하한 5:하락
+    @SerialName("bstp_nmix_prdy_ctrt")
+    val priceChangeRate: String, // 전일 대비율
+    @SerialName("acml_vol")
+    val volume: String, // 누적 거래량
+    @SerialName("bstp_nmix_oprc")
+    val open: String, // 시가
+    @SerialName("bstp_nmix_hgpr")
+    val high: String, // 고가
+    @SerialName("bstp_nmix_lwpr")
+    val low: String, // 저가
+)

--- a/app/src/main/java/com/trueedu/project/model/ws/RealTimeIndex.kt
+++ b/app/src/main/java/com/trueedu/project/model/ws/RealTimeIndex.kt
@@ -1,0 +1,40 @@
+package com.trueedu.project.model.ws
+
+/**
+ * 실시간 업종지수 (H0UPCNT0)
+ * fields:
+ * 업종코드|업종현재지수|전일대비부호|전일대비|전일대비율|누적거래량|시가|고가|저가
+ */
+class RealTimeIndex(
+    val data: List<String>
+) {
+    companion object {
+        fun from(rawData: String): RealTimeIndex {
+            return RealTimeIndex(
+                data = rawData.split("^")
+            )
+        }
+    }
+
+    // 업종코드 (0001: 코스피, 1001: 코스닥)
+    val code = data[0]
+    // 업종 현재지수
+    val price = data[1].toDouble()
+    // 전일 대비 부호: 1:상한 2:상승 3:보합 4:하한 5:하락
+    val sign = data[2]
+    // 전일 대비
+    val delta = data[3].toDouble()
+    // 전일 대비율(%)
+    val rate = data[4].toDouble()
+    // 누적 거래량
+    val volume = data[5].toDouble()
+    // 시가
+    val open = data[6].toDouble()
+    // 고가
+    val high = data[7].toDouble()
+    // 저가
+    val low = data[8].toDouble()
+
+    // 전일 종가
+    val previousClose = price - delta
+}

--- a/app/src/main/java/com/trueedu/project/model/ws/TransactionId.kt
+++ b/app/src/main/java/com/trueedu/project/model/ws/TransactionId.kt
@@ -19,4 +19,6 @@ enum class TransactionId(val value: String) {
     TradeNotification("H0STCNI0"), // 체결 통보 (실전)
     @SerialName("H0STCNI9")
     TradeNotificationTest("H0STCNI9"), // 체결 통보 (모의)
+    @SerialName("H0UPCNT0")
+    RealTimeIndex("H0UPCNT0"), // 실시간 업종지수
 }

--- a/app/src/main/java/com/trueedu/project/repository/remote/PriceRemote.kt
+++ b/app/src/main/java/com/trueedu/project/repository/remote/PriceRemote.kt
@@ -1,6 +1,7 @@
 package com.trueedu.project.repository.remote
 
 import com.trueedu.project.model.dto.price.DailyPriceResponse
+import com.trueedu.project.model.dto.price.IndexResponse
 import com.trueedu.project.model.dto.price.PriceResponse
 import com.trueedu.project.model.dto.price.TradeResponse
 import kotlinx.coroutines.flow.Flow
@@ -18,4 +19,7 @@ interface PriceRemote {
      * 일 별 시세 - 최대 30건
      */
     fun dailyPrice(code: String, from: String, to: String): Flow<DailyPriceResponse>
+
+    // 업종지수 (코스피: "0001", 코스닥: "1001")
+    fun indexPrice(code: String): Flow<IndexResponse>
 }

--- a/app/src/main/java/com/trueedu/project/repository/remote/PriceRemoteImpl.kt
+++ b/app/src/main/java/com/trueedu/project/repository/remote/PriceRemoteImpl.kt
@@ -1,6 +1,7 @@
 package com.trueedu.project.repository.remote
 
 import com.trueedu.project.di.NormalService
+import com.trueedu.project.model.dto.price.IndexResponse
 import com.trueedu.project.model.dto.price.TradeResponse
 import com.trueedu.project.network.apiCallFlow
 import com.trueedu.project.repository.remote.service.PriceService
@@ -52,5 +53,17 @@ class PriceRemoteImpl(
             "FID_ORG_ADJ_PRC" to "1", // 	0:수정주가 1:원주가
         )
         priceService.dailyPrice(headers, queries)
+    }
+
+    override fun indexPrice(code: String) = apiCallFlow {
+        val headers = mapOf(
+            "tr_id" to "FHPUP02100000",
+            "custtype" to "P",
+        )
+        val queries = mapOf(
+            "FID_COND_MRKT_DIV_CODE" to "U",
+            "FID_INPUT_ISCD" to code,
+        )
+        priceService.indexPrice(headers, queries)
     }
 }

--- a/app/src/main/java/com/trueedu/project/repository/remote/service/PriceService.kt
+++ b/app/src/main/java/com/trueedu/project/repository/remote/service/PriceService.kt
@@ -1,6 +1,7 @@
 package com.trueedu.project.repository.remote.service
 
 import com.trueedu.project.model.dto.price.DailyPriceResponse
+import com.trueedu.project.model.dto.price.IndexResponse
 import com.trueedu.project.model.dto.price.PriceResponse
 import com.trueedu.project.model.dto.price.TradeResponse
 import retrofit2.Response
@@ -26,4 +27,10 @@ interface PriceService {
         @HeaderMap headers: Map<String, String>,
         @QueryMap queries: Map<String, String>
     ): Response<DailyPriceResponse>
+
+    @GET("uapi/domestic-stock/v1/quotations/inquire-index-price")
+    suspend fun indexPrice(
+        @HeaderMap headers: Map<String, String>,
+        @QueryMap queries: Map<String, String>
+    ): Response<IndexResponse>
 }


### PR DESCRIPTION
## 변경사항

### 신규 파일
- `IndexResponse.kt` — 업종지수 REST API 응답 DTO
- `RealTimeIndex.kt` — 웹소켓 실시간 업종지수 데이터 모델 (H0UPCNT0)
- `MarketIndexManager.kt` — 코스피/코스닥 동시 구독 관리 (RealPriceManager 패턴)

### 수정 파일
- `TransactionId.kt` — `RealTimeIndex("H0UPCNT0")` 추가
- `PriceService.kt` — `indexPrice()` Retrofit 인터페이스 추가
- `PriceRemote.kt` — `indexPrice(code)` 메서드 선언
- `PriceRemoteImpl.kt` — tr_id `FHPUP02100000`, `FID_COND_MRKT_DIV_CODE=U` 구현
- `WsMessageHandler.kt` — `indexSignal` 추가, `RealTimeIndex` 케이스 처리

## API 정보
- REST: `GET /uapi/domestic-stock/v1/quotations/inquire-index-price` (tr_id: FHPUP02100000)
- WebSocket: tr_id `H0UPCNT0`, tr_key `0001`(코스피) / `1001`(코스닥)
- 웹소켓 구독 테스트 완료 ✅