### PR TITLE
관심종목 화면 복귀 시 실시간 가격 재구독 안 되는 버그 수정

### DIFF
--- a/app/src/main/java/com/trueedu/project/ui/views/watch/WatchListViewModel.kt
+++ b/app/src/main/java/com/trueedu/project/ui/views/watch/WatchListViewModel.kt
@@ -56,6 +56,15 @@ class WatchListViewModel @Inject constructor(
             loading.value = false
         }
 
+        // 화면 복귀 시 즉시 재구독
+        // combine + distinctUntilChanged 조합은 list/page 가 변경되지 않으면 emit 을 막기 때문에,
+        // onStop() 에서 해제된 구독이 복귀 시 자동으로 복구되지 않는다.
+        // 또한 makeRequest() 는 호출 시점의 currentTradeTransactionId() 를 사용하므로
+        // 재구독 시 NXT 여부도 자동으로 반영된다.
+        if (!loading.value && currentPage.value != null && hasAppKey()) {
+            requestRealtimePrice()
+        }
+
         job = viewModelScope.launch {
             launch {
                 combine(


### PR DESCRIPTION
## 문제
- 관심종목 탭에서 실시간 가격이 표시되다가, 다른 화면으로 이탈 후 복귀하면 실시간 가격이 멈추는 버그
- 장 중에 가격이 나오다가 애프터장 시간에 복귀하면 NXT 가격이 추가로 표시되지 않는 버그

## 원인
`init()` 에서 `combine + distinctUntilChanged()` 조합 사용 시, 관심 종목 목록과 현재 페이지가 변경되지 않으면 flow emit 이 차단됨.

`onStop()` → `popRequest("watch")` 로 구독 해제 후, 화면 복귀 시 `init()` 가 다시 호출되어도 flow 가 emit 되지 않아 `requestRealtimePrice()` 가 호출되지 않음.

NXT 전환 문제도 동일한 원인으로, 재구독이 안 되니 `makeRequest()` 내 `currentTradeTransactionId()` 가 호출될 기회가 없었던 것.

## 수정
`init()` 진입 시, 로딩 완료 + 페이지 확정 + 앱키 있는 상태라면 즉시 `requestRealtimePrice()` 호출하여 재구독.

NXT 여부는 `makeRequest()` 호출 시점의 `currentTradeTransactionId()` 로 자동 반영되므로 별도 처리 불필요.