### PR TITLE
관심종목 변경 시 실시간 재구독 및 현재가 자동 로드

### DIFF
--- a/app/src/main/java/com/trueedu/project/ui/views/watch/WatchListViewModel.kt
+++ b/app/src/main/java/com/trueedu/project/ui/views/watch/WatchListViewModel.kt
@@ -56,6 +56,15 @@ class WatchListViewModel @Inject constructor(
             loading.value = false
         }
 
+        // 화면 복귀 시 즉시 재구독
+        // combine + distinctUntilChanged 조합은 list/page 가 변경되지 않으면 emit 을 막기 때문에,
+        // onStop() 에서 해제된 구독이 복귀 시 자동으로 복구되지 않는다.
+        // 또한 makeRequest() 는 호출 시점의 currentTradeTransactionId() 를 사용하므로
+        // 재구독 시 NXT 여부도 자동으로 반영된다.
+        if (!loading.value && currentPage.value != null && hasAppKey()) {
+            requestRealtimePrice()
+        }
+
         job = viewModelScope.launch {
             launch {
                 combine(


### PR DESCRIPTION
## 변경 내용

- `handleWatchListChange` 신규 콜백 추가 → `SearchModal`에 연결
- 관심종목 추가/삭제 시 WebSocket 재구독 처리 (`applyWsSubscription`)
  - 추가된 종목: subscribe
  - 삭제된 종목: unsubscribe
- 신규 종목 현재가 자동 조회 (`loadGroupPrices` merge 모드)
  - `merge=false` (기본, 그룹 전환 시): prices 초기화 후 전체 조회
  - `merge=true` (종목 추가 시): 기존 prices 유지하며 신규 종목만 추가