### PR TITLE
fix: OrderFragment 백그라운드 복귀 시 크래시 수정

### DIFF
--- a/app/src/main/java/com/trueedu/project/ui/views/order/OrderFragment.kt
+++ b/app/src/main/java/com/trueedu/project/ui/views/order/OrderFragment.kt
@@ -36,18 +36,22 @@ import javax.inject.Inject
 @AndroidEntryPoint
 class OrderFragment: BaseFragment() {
     companion object {
+        private const val KEY_CODE = "code"
+
         fun show(
             code: String,
             fragmentManager: FragmentManager
         ): OrderFragment {
             val fragment = OrderFragment()
-            fragment.code = code
+            fragment.arguments = Bundle().apply { putString(KEY_CODE, code) }
             fragment.show(fragmentManager, "trading")
             return fragment
         }
     }
 
-    lateinit var code: String
+    private val code: String by lazy {
+        requireArguments().getString(KEY_CODE)!!
+    }
     private val vm by viewModels<OrderViewModel>()
     private val modifyVm by viewModels<OrderModifyViewModel>()
     private val executionVm by viewModels<OrderExecutionViewModel>()


### PR DESCRIPTION
## 문제

앱이 백그라운드 → 포그라운드로 복귀할 때 `OrderFragment`가 재생성되면서 `code` 프로퍼티가 초기화되지 않아 크래시 발생.

```
Fatal Exception: kotlin.UninitializedPropertyAccessException
lateinit property code has not been initialized
at com.trueedu.project.ui.views.order.OrderFragment.getCode (OrderFragment.kt:50)
```

## 원인

`show()`에서 `fragment.code = code`로 직접 프로퍼티에 할당하는 방식 사용.
Android가 Fragment를 재생성할 때 이 할당 과정이 실행되지 않아 `code`가 uninitalized 상태로 남음.

## 수정

`lateinit var code` 직접 할당 → `arguments Bundle` 방식으로 변경.
Android는 Fragment 재생성 시 arguments를 자동으로 복원하므로 백그라운드 복귀 후에도 `code`가 정상 초기화됨.

```kotlin
// Before
fragment.code = code
lateinit var code: String

// After
fragment.arguments = Bundle().apply { putString(KEY_CODE, code) }
private val code: String by lazy { requireArguments().getString(KEY_CODE)!! }
```