### PR TITLE
fix: HTTP 500 에러로 인한 FATAL EXCEPTION 크래시 수정

### DIFF
--- a/app/src/main/java/com/trueedu/project/ui/views/order/OrderViewModel.kt
+++ b/app/src/main/java/com/trueedu/project/ui/views/order/OrderViewModel.kt
@@ -95,6 +95,7 @@ class OrderViewModel @Inject constructor(
                 logD("호가 api: $it")
                 tradeBase.value = it
             }
+            .catch { logD("호가 api 오류: $it") }
             .launchIn(viewModelScope)
 
         // 가격 기본값
@@ -107,6 +108,7 @@ class OrderViewModel @Inject constructor(
                     )
                 }
             }
+            .catch { logD("현재가 api 오류: $it") }
             .launchIn(viewModelScope)
 
         viewModelScope.launch {

--- a/app/src/main/java/com/trueedu/project/ui/views/stock/DailyPriceViewModel.kt
+++ b/app/src/main/java/com/trueedu/project/ui/views/stock/DailyPriceViewModel.kt
@@ -8,6 +8,7 @@ import com.trueedu.project.model.dto.price.DailyPriceResponse
 import com.trueedu.project.repository.remote.PriceRemote
 import com.trueedu.project.utils.yyyyMMdd
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import java.time.LocalDate
@@ -63,6 +64,7 @@ class DailyPriceViewModel @Inject constructor(
                 }
                 loading.value = false
             }
+            .catch { logD("일별 시세 api 오류: $it") }
             .launchIn(viewModelScope)
     }
 }


### PR DESCRIPTION
## 문제

KIS API 서버에서 HTTP 500을 반환할 때 `.catch {}` 핸들러가 없는 flow가 예외를 Main thread까지 전파시켜 FATAL EXCEPTION 크래시 발생.

```
FATAL EXCEPTION: main
retrofit2.HttpException: HTTP 500 Internal Server Error
at com.trueedu.project.network.ApiHandlerKt.handleApi(ApiHandler.kt:13)
```

## 원인

`apiCallFlow`는 내부에서 `throw HttpException`을 하는 구조이므로, 구독하는 쪽에서 반드시 `.catch {}`로 예외를 처리해야 함. 일부 ViewModel에서 누락되어 있었음.

## 수정

- `OrderViewModel`: `currentTrade`, `currentPrice` flow에 `.catch` 추가
- `DailyPriceViewModel`: `dailyPrice` flow에 `.catch` 추가

(다른 ViewModel들은 이미 `.catch {}` 처리 되어 있음 확인)